### PR TITLE
fix(nft-api): order by height and token id

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1118,9 +1118,17 @@ const docTemplate = `{
                     ],
                     "x-order:1": true
                 },
+                "height": {
+                    "type": "integer",
+                    "x-order:2": true
+                },
                 "object_addr": {
                     "type": "string",
                     "x-order:0": true
+                },
+                "timestamp": {
+                    "type": "string",
+                    "x-order:3": true
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -1107,9 +1107,17 @@
                     ],
                     "x-order:1": true
                 },
+                "height": {
+                    "type": "integer",
+                    "x-order:2": true
+                },
                 "object_addr": {
                     "type": "string",
                     "x-order:0": true
+                },
+                "timestamp": {
+                    "type": "string",
+                    "x-order:3": true
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -17,9 +17,15 @@ definitions:
         allOf:
         - $ref: '#/definitions/nft.CollectionDetail'
         x-order:1: true
+      height:
+        type: integer
+        x-order:2: true
       object_addr:
         type: string
         x-order:0: true
+      timestamp:
+        type: string
+        x-order:3: true
     type: object
   nft.CollectionDetail:
     properties:

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -63,7 +63,7 @@ func (h *NftHandler) GetTokensByAccount(c *fiber.Ctx) error {
 
 	var nfts []types.CollectedNft
 	if err := query.
-		Order(pagination.OrderBy("collection_addr", "token_id")).
+		Order(pagination.OrderBy("height", "token_id")).
 		Offset(pagination.Offset).
 		Limit(pagination.Limit).
 		Find(&nfts).Error; err != nil {
@@ -124,7 +124,7 @@ func (h *NftHandler) GetTokensByCollectionAddr(c *fiber.Ctx) error {
 
 	var nfts []types.CollectedNft
 	if err := query.
-		Order(pagination.OrderBy("token_id")).
+		Order(pagination.OrderBy("height", "token_id")).
 		Offset(pagination.Offset).
 		Limit(pagination.Limit).
 		Find(&nfts).Error; err != nil {

--- a/api/handler/nft/types.go
+++ b/api/handler/nft/types.go
@@ -27,6 +27,8 @@ type CollectionDetail struct {
 type Collection struct {
 	Address          string           `json:"object_addr" extensions:"x-order:0"`
 	CollectionDetail CollectionDetail `json:"collection" extensions:"x-order:1"`
+	Height           int64            `json:"height" extensions:"x-order:2"`
+	Timestamp        time.Time        `json:"timestamp" extensions:"x-order:3"`
 }
 
 type CollectionsResponse struct {
@@ -50,6 +52,8 @@ func ToCollectionResponse(col types.CollectedNftCollection, creatorAccount []byt
 				Length: col.NftCount,
 			},
 		},
+		Height:    col.Height,
+		Timestamp: col.Timestamp,
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new properties, "height" and "timestamp", to the NFT collection object in the API responses and documentation.

* **Bug Fixes**
  * Updated the ordering of NFT tokens in API responses to use "height" and "token_id" for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->