### PR TITLE
fix(pagination): default pagination limit is 1000

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -59,7 +59,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -126,7 +126,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -182,7 +182,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -238,7 +238,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -338,7 +338,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -400,7 +400,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -463,7 +463,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -505,7 +505,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -560,7 +560,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -615,7 +615,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -670,7 +670,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -718,7 +718,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -767,7 +767,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -822,7 +822,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -889,7 +889,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -949,7 +949,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -1015,7 +1015,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -115,7 +115,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -171,7 +171,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -227,7 +227,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -327,7 +327,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -389,7 +389,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -452,7 +452,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -494,7 +494,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -549,7 +549,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -604,7 +604,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -659,7 +659,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -707,7 +707,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -756,7 +756,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -811,7 +811,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -878,7 +878,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -938,7 +938,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },
@@ -1004,7 +1004,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Pagination limit, default is 100",
+                        "description": "Pagination limit, default is 1000",
                         "name": "pagination.limit",
                         "in": "query"
                     },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -165,7 +165,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -211,7 +211,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -270,7 +270,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -308,7 +308,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -354,7 +354,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -396,7 +396,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -439,7 +439,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -468,7 +468,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -506,7 +506,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -544,7 +544,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -582,7 +582,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -615,7 +615,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -666,7 +666,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -704,7 +704,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -733,7 +733,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -792,7 +792,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer
@@ -838,7 +838,7 @@ paths:
         in: query
         name: pagination.offset
         type: integer
-      - description: Pagination limit, default is 100
+      - description: Pagination limit, default is 1000
         in: query
         name: pagination.limit
         type: integer

--- a/api/handler/block/block.go
+++ b/api/handler/block/block.go
@@ -18,7 +18,7 @@ import (
 // @Produce json
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100"
+// @Param pagination.limit query int false "Pagination limit, default is 1000"
 // @Param pagination.reverse query bool false "Reverse order, default is true. if set to true, the results will be ordered in descending order"
 // @Router /indexer/block/v1/blocks [get]
 func (h *BlockHandler) GetBlocks(c *fiber.Ctx) error {

--- a/api/handler/common/pagination.go
+++ b/api/handler/common/pagination.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	DefaultLimit  = 100
+	DefaultLimit  = 1000
 	MaxLimit      = 1000
 	DefaultOffset = 0
 	OrderDesc     = "DESC"

--- a/api/handler/nft/collection.go
+++ b/api/handler/nft/collection.go
@@ -18,7 +18,7 @@ import (
 // @Produce json
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Success 200 {object} CollectionsResponse
 // @Router /indexer/nft/v1/collections [get]
@@ -64,7 +64,7 @@ func (h *NftHandler) GetCollections(c *fiber.Ctx) error {
 // @Param account path string true "Account address"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Success 200 {object} CollectionsResponse
 // @Router /indexer/nft/v1/collections/by_account/{account} [get]
@@ -130,7 +130,7 @@ func (h *NftHandler) GetCollectionsByAccount(c *fiber.Ctx) error {
 // @Param name path string true "Collection name"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Success 200 {object} CollectionsResponse
 // @Router /indexer/nft/v1/collections/by_name/{name} [get]

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -19,7 +19,7 @@ import (
 // @Param token_id query string false "Token ID to filter by (optional)"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Success 200 {object} NftsResponse
 // @Router /indexer/nft/v1/tokens/by_account/{account} [get]
@@ -96,7 +96,7 @@ func (h *NftHandler) GetTokensByAccount(c *fiber.Ctx) error {
 // @Param token_id query string false "Token ID to filter by (optional)"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Success 200 {object} NftsResponse
 // @Router /indexer/nft/v1/tokens/by_collection/{collection_addr} [get]

--- a/api/handler/nft/tx.go
+++ b/api/handler/nft/tx.go
@@ -24,7 +24,7 @@ import (
 // @Param token_id path string true "Token ID"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Router /indexer/nft/v1/txs/{collection_addr}/{token_id} [get]
 func (h *NftHandler) GetNftTxs(c *fiber.Ctx) error {

--- a/api/handler/tx/evmtx.go
+++ b/api/handler/tx/evmtx.go
@@ -20,7 +20,7 @@ import (
 // @Produce json
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Router /indexer/tx/v1/evm-txs [get]
 func (h *TxHandler) GetEvmTxs(c *fiber.Ctx) error {
@@ -67,7 +67,7 @@ func (h *TxHandler) GetEvmTxs(c *fiber.Ctx) error {
 // @Param account path string true "Account address"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Param is_signer query bool false "Filter by signer accounts, default is false" default is false
 // @Router /indexer/tx/v1/evm-txs/by_account/{account} [get]
@@ -130,7 +130,7 @@ func (h *TxHandler) GetEvmTxsByAccount(c *fiber.Ctx) error {
 // @Param height path int true "Block height"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Router /indexer/tx/v1/evm-txs/by_height/{height} [get]
 func (h *TxHandler) GetEvmTxsByHeight(c *fiber.Ctx) error {

--- a/api/handler/tx/internaltx.go
+++ b/api/handler/tx/internaltx.go
@@ -20,7 +20,7 @@ import (
 // @Produce json
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.count_total query bool false "Count total, default is true" default is true
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Router /indexer/tx/v1/evm-internal-txs [get]
@@ -76,7 +76,7 @@ func (h *TxHandler) GetEvmInternalTxs(c *fiber.Ctx) error {
 // @Param account path string true "Account address"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.count_total query bool false "Count total, default is true" default is true
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Router /indexer/tx/v1/evm-internal-txs/by_account/{account} [get]
@@ -138,7 +138,7 @@ func (h *TxHandler) GetEvmInternalTxsByAccount(c *fiber.Ctx) error {
 // @Param height path int true "Block height"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.count_total query bool false "Count total, default is true" default is true
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Router /indexer/tx/v1/evm-internal-txs/by_height/{height} [get]
@@ -196,7 +196,7 @@ func (h *TxHandler) GetEvmInternalTxsByHeight(c *fiber.Ctx) error {
 // @Param tx_hash path string true "Transaction hash"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.count_total query bool false "Count total, default is true" default is true
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Router /indexer/tx/v1/evm-internal-txs/{tx_hash} [get]

--- a/api/handler/tx/tx.go
+++ b/api/handler/tx/tx.go
@@ -20,7 +20,7 @@ import (
 // @Produce json
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Param msgs query []string false "Message types to filter (comma-separated or multiple params)" collectionFormat(multi) example("cosmos.bank.v1beta1.MsgSend,initia.move.v1.MsgExecute")
 // @Router /indexer/tx/v1/txs [get]
@@ -83,7 +83,7 @@ func (h *TxHandler) GetTxs(c *fiber.Ctx) error {
 // @Param account path string true "Account address"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Param is_signer query bool false "Filter by signer accounts, default is false" default is false
 // @Param msgs query []string false "Message types to filter (comma-separated or multiple params)" collectionFormat(multi) example("cosmos.bank.v1beta1.MsgSend,initia.move.v1.MsgExecute")
@@ -155,7 +155,7 @@ func (h *TxHandler) GetTxsByAccount(c *fiber.Ctx) error {
 // @Param height path int true "Block height"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
-// @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
+// @Param pagination.limit query int false "Pagination limit, default is 1000" default is 1000
 // @Param pagination.reverse query bool false "Reverse order default is true if set to true, the results will be ordered in descending order"
 // @Param msgs query []string false "Message types to filter (comma-separated or multiple params)" collectionFormat(multi) example("cosmos.bank.v1beta1.MsgSend,initia.move.v1.MsgExecute")
 // @Router /indexer/tx/v1/txs/by_height/{height} [get]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to reflect an increased default pagination limit from 100 to 1000 for multiple endpoints, including blocks, NFT collections and tokens, EVM internal transactions, EVM transactions, and general transactions.
* **Chores**
  * Increased the default pagination limit setting from 100 to 1000 for relevant API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->