### PR TITLE
chore: update swagger

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -836,31 +836,6 @@ const docTemplate = `{
                 "responses": {}
             }
         },
-        "/indexer/tx/v1/evm-txs/{tx_hash}": {
-            "get": {
-                "description": "Get a specific EVM transaction by its hash",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "EVM Tx"
-                ],
-                "summary": "Get EVM transaction by hash",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Transaction hash",
-                        "name": "tx_hash",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            }
-        },
         "/indexer/tx/v1/txs": {
             "get": {
                 "description": "Get a list of transactions with pagination",
@@ -1035,31 +1010,6 @@ const docTemplate = `{
                         "description": "Message types to filter (comma-separated or multiple params)",
                         "name": "msgs",
                         "in": "query"
-                    }
-                ],
-                "responses": {}
-            }
-        },
-        "/indexer/tx/v1/txs/{tx_hash}": {
-            "get": {
-                "description": "Get a specific transaction by its hash",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Tx"
-                ],
-                "summary": "Get transaction by hash",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Transaction hash",
-                        "name": "tx_hash",
-                        "in": "path",
-                        "required": true
                     }
                 ],
                 "responses": {}

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -825,31 +825,6 @@
                 "responses": {}
             }
         },
-        "/indexer/tx/v1/evm-txs/{tx_hash}": {
-            "get": {
-                "description": "Get a specific EVM transaction by its hash",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "EVM Tx"
-                ],
-                "summary": "Get EVM transaction by hash",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Transaction hash",
-                        "name": "tx_hash",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {}
-            }
-        },
         "/indexer/tx/v1/txs": {
             "get": {
                 "description": "Get a list of transactions with pagination",
@@ -1024,31 +999,6 @@
                         "description": "Message types to filter (comma-separated or multiple params)",
                         "name": "msgs",
                         "in": "query"
-                    }
-                ],
-                "responses": {}
-            }
-        },
-        "/indexer/tx/v1/txs/{tx_hash}": {
-            "get": {
-                "description": "Get a specific transaction by its hash",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Tx"
-                ],
-                "summary": "Get transaction by hash",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Transaction hash",
-                        "name": "tx_hash",
-                        "in": "path",
-                        "required": true
                     }
                 ],
                 "responses": {}

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -630,23 +630,6 @@ paths:
       summary: Get EVM transactions
       tags:
       - EVM Tx
-  /indexer/tx/v1/evm-txs/{tx_hash}:
-    get:
-      consumes:
-      - application/json
-      description: Get a specific EVM transaction by its hash
-      parameters:
-      - description: Transaction hash
-        in: path
-        name: tx_hash
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses: {}
-      summary: Get EVM transaction by hash
-      tags:
-      - EVM Tx
   /indexer/tx/v1/evm-txs/by_account/{account}:
     get:
       consumes:
@@ -754,23 +737,6 @@ paths:
       - application/json
       responses: {}
       summary: Get transactions
-      tags:
-      - Tx
-  /indexer/tx/v1/txs/{tx_hash}:
-    get:
-      consumes:
-      - application/json
-      description: Get a specific transaction by its hash
-      parameters:
-      - description: Transaction hash
-        in: path
-        name: tx_hash
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses: {}
-      summary: Get transaction by hash
       tags:
       - Tx
   /indexer/tx/v1/txs/by_account/{account}:


### PR DESCRIPTION
#32 missed it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Removed API documentation for two GET endpoints that retrieve transactions by hash: /indexer/tx/v1/evm-txs/{tx_hash} and /indexer/tx/v1/txs/{tx_hash}.
  - These endpoints no longer appear in the published Swagger/OpenAPI specification.
  - All other documented endpoints remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->