### PR TITLE
chore: update default query timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can configure rollytics using environment variables. All settings can be con
 ### Performance Settings
 
 - `COOLING_DURATION`: Cooling period between operations (optional, default: `50ms`)
-- `QUERY_TIMEOUT`: Query timeout duration (optional, default: `10s`)
+- `QUERY_TIMEOUT`: Query timeout duration (optional, default: `30s`)
 - `MAX_CONCURRENT_REQUESTS`: Maximum concurrent requests (optional, default: `50`, max: `1000`)
 - `POLLING_INTERVAL`: API polling interval (optional, default: `3s`)
 
@@ -138,7 +138,7 @@ export VM_TYPE='evm'
 export VM_TYPE='move'
 # INTERNAL_TX=false (default)
 
-# Wasm chains - INTERNAL_TX disabled by default  
+# Wasm chains - INTERNAL_TX disabled by default
 export VM_TYPE='wasm'
 # INTERNAL_TX=false (default)
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ const (
 
 	// Timeout and interval settings
 	DefaultCoolingDuration = 50 * time.Millisecond
-	DefaultQueryTimeout    = 10 * time.Second
+	DefaultQueryTimeout    = 30 * time.Second
 	DefaultPollingInterval = 3 * time.Second
 
 	// Concurrent request settings


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default query timeout to 30 seconds (previously 10 seconds). Users without custom overrides will now have a longer default timeout.
* **Documentation**
  * Updated README to reflect the new default query timeout.
  * Minor formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->