### PR TITLE
feat(api): filter Swagger documentation for non-EVM VM types

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -167,7 +167,7 @@ func New(cfg *config.Config, logger *slog.Logger, db *orm.Database) *Api {
 
 			var spec map[string]any
 			if err := json.Unmarshal([]byte(swaggerData), &spec); err != nil {
-				return c.JSON(docs.SwaggerInfo)
+				return c.Type("json").SendString(swaggerData)
 			}
 
 			if paths, ok := spec["paths"].(map[string]any); ok {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Swagger docs for non-EVM deployments now omit EVM-specific endpoints so the published spec matches the configured VM type and reduces confusion.
  * A filtered Swagger JSON endpoint is provided alongside the unchanged standard Swagger UI routes.
  * EVM deployments continue to receive the full endpoint set.
  * No runtime behavior or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->