### PR TITLE
chore(api): update collection addr normalizer to support both of hex and bech32

### DIFF
--- a/api/handler/common/param.go
+++ b/api/handler/common/param.go
@@ -56,7 +56,7 @@ func GetCollectionAddrParam(c *fiber.Ctx, config *config.ChainConfig) ([]byte, e
 		return nil, err
 	}
 
-	return normalizeCollectionAddr(collectionAddr, config)
+	return normalizeCollectionAddr(collectionAddr)
 }
 
 func GetMsgsQuery(c *fiber.Ctx) (msgs []string) {
@@ -73,5 +73,5 @@ func GetCollectionAddrQuery(c *fiber.Ctx, config *config.ChainConfig) ([]byte, e
 		return nil, nil
 	}
 
-	return normalizeCollectionAddr(collectionAddr, config)
+	return normalizeCollectionAddr(collectionAddr)
 }

--- a/api/handler/common/util.go
+++ b/api/handler/common/util.go
@@ -1,38 +1,14 @@
 package common
 
 import (
-	"errors"
-	"strings"
-
-	"github.com/initia-labs/rollytics/config"
-	"github.com/initia-labs/rollytics/types"
 	"github.com/initia-labs/rollytics/util"
 )
 
-// normalizeCollectionAddr parses collection address based on VM type
-func normalizeCollectionAddr(collectionAddr string, config *config.ChainConfig) ([]byte, error) {
-	switch config.VmType {
-	case types.MoveVM:
-		accAddr, err := util.AccAddressFromString(collectionAddr)
-		if err != nil {
-			return nil, err
-		}
-		return accAddr.Bytes(), nil
-	case types.EVM:
-		if !strings.HasPrefix(collectionAddr, "0x") {
-			return nil, errors.New("collection address should be hex address")
-		}
-		return util.HexToBytes(strings.ToLower(collectionAddr))
-	case types.WasmVM:
-		if !strings.HasPrefix(collectionAddr, config.AccountAddressPrefix) {
-			return nil, errors.New("collection address should be bech32 address")
-		}
-		accAddr, err := util.AccAddressFromString(collectionAddr)
-		if err != nil {
-			return nil, err
-		}
-		return accAddr.Bytes(), nil
-	default:
-		return nil, errors.New("unsupported vm type")
+// normalizeCollectionAddr parses collection address (supports both hex and bech32)
+func normalizeCollectionAddr(collectionAddr string) ([]byte, error) {
+	accAddr, err := util.AccAddressFromString(collectionAddr)
+	if err != nil {
+		return nil, err
 	}
+	return accAddr.Bytes(), nil
 }


### PR DESCRIPTION
* update collection addr normalizer to support both of hex and bech32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified address input: Supports both hex and bech32 formats consistently across networks.
- Bug Fixes
  - Reduced address parsing failures caused by VM-specific handling inconsistencies.
- Refactor
  - Simplified address normalization to a single, consistent parsing path for improved reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->