### PR TITLE
fix(evm): default internal_tx value on evm

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -163,7 +163,7 @@ func loadConfig() (*Config, error) {
 		fmt.Fprintln(os.Stderr, "No .env file found")
 	}
 	viper.AutomaticEnv()
-	
+
 	var vmType types.VMType
 	switch viper.GetString("VM_TYPE") {
 	case "move":


### PR DESCRIPTION
fix setVMSpecificDefaults to work by adjusting calling order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default internal-transaction setting now depends on VM type: enabled for EVM, disabled for non-EVM.
  * Explicit user configuration (env/config) still overrides defaults.
  * Startup ordering improved so database configuration is initialized after defaults are resolved, ensuring consistent effective settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->