### PR TITLE
fix: pagination

### DIFF
--- a/api/handler/common/pagination.go
+++ b/api/handler/common/pagination.go
@@ -73,8 +73,7 @@ func (p *Pagination) OrderBy(keys ...string) string {
 
 func (p *Pagination) ToResponse(total int64) (res PaginationResponse) {
 	if total > int64(p.Offset+p.Limit) {
-		// Add +1 to prevent overlap: ensures next page doesn't include current page's last item
-		nextKey := base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(p.Offset + p.Limit + 1)))
+		nextKey := base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(p.Offset + p.Limit)))
 		res.NextKey = &nextKey
 	}
 	// if offset is greater than or equal to limit, previousKey can be set


### PR DESCRIPTION
* fix: boundary case where offset equals limit for prev_key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate items between consecutive pages by refining page-boundary handling.
  * Ensures the “Previous” link appears when landing exactly on a full-page boundary.
  * Maintains consistent “Next” link behavior based on total results; no change to visible endpoints.

* **Chores**
  * Clarified internal comments about pagination behavior.
  * No changes to public APIs or response formats; fully backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->