### PR TITLE
fix(internal-tx): skip indexing in failed transaction

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -836,6 +836,31 @@ const docTemplate = `{
                 "responses": {}
             }
         },
+        "/indexer/tx/v1/evm-txs/{tx_hash}": {
+            "get": {
+                "description": "Get a specific EVM transaction by its hash",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "EVM Tx"
+                ],
+                "summary": "Get EVM transaction by hash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Transaction hash",
+                        "name": "tx_hash",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/indexer/tx/v1/txs": {
             "get": {
                 "description": "Get a list of transactions with pagination",
@@ -1010,6 +1035,31 @@ const docTemplate = `{
                         "description": "Message types to filter (comma-separated or multiple params)",
                         "name": "msgs",
                         "in": "query"
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/indexer/tx/v1/txs/{tx_hash}": {
+            "get": {
+                "description": "Get a specific transaction by its hash",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tx"
+                ],
+                "summary": "Get transaction by hash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Transaction hash",
+                        "name": "tx_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {}

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -825,6 +825,31 @@
                 "responses": {}
             }
         },
+        "/indexer/tx/v1/evm-txs/{tx_hash}": {
+            "get": {
+                "description": "Get a specific EVM transaction by its hash",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "EVM Tx"
+                ],
+                "summary": "Get EVM transaction by hash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Transaction hash",
+                        "name": "tx_hash",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/indexer/tx/v1/txs": {
             "get": {
                 "description": "Get a list of transactions with pagination",
@@ -999,6 +1024,31 @@
                         "description": "Message types to filter (comma-separated or multiple params)",
                         "name": "msgs",
                         "in": "query"
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/indexer/tx/v1/txs/{tx_hash}": {
+            "get": {
+                "description": "Get a specific transaction by its hash",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tx"
+                ],
+                "summary": "Get transaction by hash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Transaction hash",
+                        "name": "tx_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {}

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -630,6 +630,23 @@ paths:
       summary: Get EVM transactions
       tags:
       - EVM Tx
+  /indexer/tx/v1/evm-txs/{tx_hash}:
+    get:
+      consumes:
+      - application/json
+      description: Get a specific EVM transaction by its hash
+      parameters:
+      - description: Transaction hash
+        in: path
+        name: tx_hash
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses: {}
+      summary: Get EVM transaction by hash
+      tags:
+      - EVM Tx
   /indexer/tx/v1/evm-txs/by_account/{account}:
     get:
       consumes:
@@ -737,6 +754,23 @@ paths:
       - application/json
       responses: {}
       summary: Get transactions
+      tags:
+      - Tx
+  /indexer/tx/v1/txs/{tx_hash}:
+    get:
+      consumes:
+      - application/json
+      description: Get a specific transaction by its hash
+      parameters:
+      - description: Transaction hash
+        in: path
+        name: tx_hash
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses: {}
+      summary: Get transaction by hash
       tags:
       - Tx
   /indexer/tx/v1/txs/by_account/{account}:

--- a/api/handler/tx/evmtx.go
+++ b/api/handler/tx/evmtx.go
@@ -181,8 +181,6 @@ func (h *TxHandler) GetEvmTxsByHeight(c *fiber.Ctx) error {
 // @Produce json
 // @Param tx_hash path string true "Transaction hash"
 // @Router /indexer/tx/v1/evm-txs/{tx_hash} [get]
-//
-
 func (h *TxHandler) GetEvmTxByHash(c *fiber.Ctx) error {
 	hash, err := common.GetParams(c, "tx_hash")
 	if err != nil {

--- a/api/handler/tx/tx.go
+++ b/api/handler/tx/tx.go
@@ -216,8 +216,6 @@ func (h *TxHandler) GetTxsByHeight(c *fiber.Ctx) error {
 // @Produce json
 // @Param tx_hash path string true "Transaction hash"
 // @Router /indexer/tx/v1/txs/{tx_hash} [get]
-//
-
 func (h *TxHandler) GetTxByHash(c *fiber.Ctx) error {
 	hash, err := common.GetParams(c, "tx_hash")
 	if err != nil {

--- a/indexer/extension/internaltx/collect.go
+++ b/indexer/extension/internaltx/collect.go
@@ -103,8 +103,11 @@ func (i *InternalTxExtension) CollectInternalTxs(db *orm.Database, internalTx *I
 		var allInternalTxs []types.CollectedEvmInternalTx
 		for _, trace := range internalTx.CallTrace.Result {
 			if trace.Error != "" {
-				return fmt.Errorf("trace error at height %d, txHash %s: %s",
-					internalTx.Height, trace.TxHash, trace.Error)
+				i.logger.Info("skip indexing in failed transaction",
+					slog.Int64("height", internalTx.Height),
+					slog.String("tx_hash", trace.TxHash),
+					slog.String("error", trace.Error))
+				return nil
 			}
 			height := internalTx.Height
 			hashHex := strings.ToLower(strings.TrimPrefix(trace.TxHash, "0x"))

--- a/indexer/extension/internaltx/collect.go
+++ b/indexer/extension/internaltx/collect.go
@@ -107,7 +107,7 @@ func (i *InternalTxExtension) CollectInternalTxs(db *orm.Database, internalTx *I
 					slog.Int64("height", internalTx.Height),
 					slog.String("tx_hash", trace.TxHash),
 					slog.String("error", trace.Error))
-				return nil
+				continue
 			}
 			height := internalTx.Height
 			hashHex := strings.ToLower(strings.TrimPrefix(trace.TxHash, "0x"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added endpoints to fetch a transaction by hash for both EVM and non-EVM transactions.

- Documentation
  - API docs updated to include the new GET endpoints for fetching transactions by hash.
  - Clarified description for fetching EVM transactions by account.

- Bug Fixes
  - Improved indexing stability by skipping failed internal transaction traces and continuing processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->