### PR TITLE
fix: adjust tx isolation level as Read Committed

### DIFF
--- a/indexer/collector/collector.go
+++ b/indexer/collector/collector.go
@@ -90,7 +90,7 @@ func (c *Collector) Collect(sb indexertypes.ScrapedBlock) error {
 
 		c.logger.Info("indexed block", slog.Int64("height", sb.Height))
 		return nil
-	}, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	}, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 
 	// handle serialization error
 	var pgErr *pgconn.PgError

--- a/indexer/extension/internaltx/collect.go
+++ b/indexer/extension/internaltx/collect.go
@@ -154,7 +154,7 @@ func (i *InternalTxExtension) CollectInternalTxs(db *orm.Database, internalTx *I
 
 		return nil
 	}, &sql.TxOptions{
-		Isolation: sql.LevelRepeatableRead,
+		Isolation: sql.LevelReadCommitted,
 	})
 	if err != nil {
 		// handle intended serialization error


### PR DESCRIPTION
I think almost we can handle almost of conflict cases with `DoNothingWhenConflict`.
for `UpdateAllWhenConflict` cases, ReadCommitted isolation level with 40001 error handling can do that.