### PR TITLE
feat: add `order_by` query parameter to NFT token API endpoints

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -325,8 +325,13 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "token_id",
+                            "height"
+                        ],
                         "type": "string",
-                        "description": "Order by field (token_id, height)",
+                        "default": "token_id",
+                        "description": "Order by field",
                         "name": "order_by",
                         "in": "query"
                     },
@@ -393,8 +398,13 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "token_id",
+                            "height"
+                        ],
                         "type": "string",
-                        "description": "Order by field (token_id, height)",
+                        "default": "token_id",
+                        "description": "Order by field",
                         "name": "order_by",
                         "in": "query"
                     },

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -326,7 +326,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Order by field (token_id, timestamp)",
+                        "description": "Order by field (token_id, height)",
                         "name": "order_by",
                         "in": "query"
                     },
@@ -394,7 +394,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Order by field (token_id, timestamp)",
+                        "description": "Order by field (token_id, height)",
                         "name": "order_by",
                         "in": "query"
                     },

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -326,6 +326,12 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Order by field (token_id, timestamp)",
+                        "name": "order_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Pagination key",
                         "name": "pagination.key",
                         "in": "query"
@@ -384,6 +390,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Token ID to filter by (optional)",
                         "name": "token_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order by field (token_id, timestamp)",
+                        "name": "order_by",
                         "in": "query"
                     },
                     {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -314,8 +314,13 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "token_id",
+                            "height"
+                        ],
                         "type": "string",
-                        "description": "Order by field (token_id, height)",
+                        "default": "token_id",
+                        "description": "Order by field",
                         "name": "order_by",
                         "in": "query"
                     },
@@ -382,8 +387,13 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "token_id",
+                            "height"
+                        ],
                         "type": "string",
-                        "description": "Order by field (token_id, height)",
+                        "default": "token_id",
+                        "description": "Order by field",
                         "name": "order_by",
                         "in": "query"
                     },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -315,6 +315,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Order by field (token_id, timestamp)",
+                        "name": "order_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Pagination key",
                         "name": "pagination.key",
                         "in": "query"
@@ -373,6 +379,12 @@
                         "type": "string",
                         "description": "Token ID to filter by (optional)",
                         "name": "token_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order by field (token_id, timestamp)",
+                        "name": "order_by",
                         "in": "query"
                     },
                     {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -315,7 +315,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Order by field (token_id, timestamp)",
+                        "description": "Order by field (token_id, height)",
                         "name": "order_by",
                         "in": "query"
                     },
@@ -383,7 +383,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Order by field (token_id, timestamp)",
+                        "description": "Order by field (token_id, height)",
                         "name": "order_by",
                         "in": "query"
                     },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -346,6 +346,10 @@ paths:
         in: query
         name: token_id
         type: string
+      - description: Order by field (token_id, timestamp)
+        in: query
+        name: order_by
+        type: string
       - description: Pagination key
         in: query
         name: pagination.key
@@ -387,6 +391,10 @@ paths:
       - description: Token ID to filter by (optional)
         in: query
         name: token_id
+        type: string
+      - description: Order by field (token_id, timestamp)
+        in: query
+        name: order_by
         type: string
       - description: Pagination key
         in: query

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -346,7 +346,7 @@ paths:
         in: query
         name: token_id
         type: string
-      - description: Order by field (token_id, timestamp)
+      - description: Order by field (token_id, height)
         in: query
         name: order_by
         type: string
@@ -392,7 +392,7 @@ paths:
         in: query
         name: token_id
         type: string
-      - description: Order by field (token_id, timestamp)
+      - description: Order by field (token_id, height)
         in: query
         name: order_by
         type: string

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -346,7 +346,11 @@ paths:
         in: query
         name: token_id
         type: string
-      - description: Order by field (token_id, height)
+      - default: token_id
+        description: Order by field
+        enum:
+        - token_id
+        - height
         in: query
         name: order_by
         type: string
@@ -392,7 +396,11 @@ paths:
         in: query
         name: token_id
         type: string
-      - description: Order by field (token_id, height)
+      - default: token_id
+        description: Order by field
+        enum:
+        - token_id
+        - height
         in: query
         name: order_by
         type: string

--- a/api/handler/common/pagination.go
+++ b/api/handler/common/pagination.go
@@ -298,13 +298,17 @@ func (p *Pagination) ApplyToNft(query *gorm.DB, orderBy string) *gorm.DB {
 	case CursorTypeComposite:
 		height, err := p.safeGetInt64("height")
 		if err != nil {
-			// Fallback to offset-based pagination on error
+			if orderBy == "height" {
+				return query.Order(p.OrderBy("height", "token_id")).Offset(p.Offset).Limit(p.Limit)
+			}
 			return query.Order(p.OrderBy("token_id", "height")).Offset(p.Offset).Limit(p.Limit)
 		}
 		tokenId, err := p.safeGetString("token_id")
 		if err != nil {
-			// Fallback to offset-based pagination on error
-			return query.Order(p.OrderBy("token_id", "height")).Offset(p.Offset).Limit(p.Limit)
+			if orderBy == "token_id" {
+				return query.Order(p.OrderBy("token_id", "height")).Offset(p.Offset).Limit(p.Limit)
+			}
+			return query.Order(p.OrderBy("height", "token_id")).Offset(p.Offset).Limit(p.Limit)
 		}
 
 		if p.Order == OrderDesc && orderBy == "height" {
@@ -322,7 +326,10 @@ func (p *Pagination) ApplyToNft(query *gorm.DB, orderBy string) *gorm.DB {
 	case CursorTypeHeight, CursorTypeOffset:
 		fallthrough
 	default:
-		return query.Order(p.OrderBy("token_id", "height")).Offset(p.Offset).Limit(p.Limit)
+		if orderBy == "token_id" {
+			return query.Order(p.OrderBy("token_id", "height")).Offset(p.Offset).Limit(p.Limit)
+		}
+		return query.Order(p.OrderBy("height", "token_id")).Offset(p.Offset).Limit(p.Limit)
 	}
 }
 

--- a/api/handler/common/pagination.go
+++ b/api/handler/common/pagination.go
@@ -311,13 +311,14 @@ func (p *Pagination) ApplyToNft(query *gorm.DB, orderBy string) *gorm.DB {
 			return query.Order(p.OrderBy("height", "token_id")).Offset(p.Offset).Limit(p.Limit)
 		}
 
-		if p.Order == OrderDesc && orderBy == "height" {
+		switch {
+		case p.Order == OrderDesc && orderBy == "height":
 			query = query.Where("(height, token_id) < (?, ?)", height, tokenId)
-		} else if p.Order == OrderDesc && orderBy == "token_id" {
+		case p.Order == OrderDesc && orderBy == "token_id":
 			query = query.Where("(token_id, height) < (?, ?)", tokenId, height)
-		} else if p.Order == OrderAsc && orderBy == "height" {
+		case p.Order == OrderAsc && orderBy == "height":
 			query = query.Where("(height, token_id) > (?, ?)", height, tokenId)
-		} else if p.Order == OrderAsc && orderBy == "token_id" {
+		case p.Order == OrderAsc && orderBy == "token_id":
 			query = query.Where("(token_id, height) > (?, ?)", tokenId, height)
 		}
 

--- a/api/handler/common/pagination.go
+++ b/api/handler/common/pagination.go
@@ -313,17 +313,15 @@ func (p *Pagination) ApplyToNft(query *gorm.DB, orderBy string) *gorm.DB {
 
 		switch {
 		case p.Order == OrderDesc && orderBy == "height":
-			query = query.Where("(height, token_id) < (?, ?)", height, tokenId)
+			return query.Where("(height, token_id) < (?, ?)", height, tokenId)
 		case p.Order == OrderDesc && orderBy == "token_id":
-			query = query.Where("(token_id, height) < (?, ?)", tokenId, height)
+			return query.Where("(token_id, height) < (?, ?)", tokenId, height)
 		case p.Order == OrderAsc && orderBy == "height":
-			query = query.Where("(height, token_id) > (?, ?)", height, tokenId)
+			return query.Where("(height, token_id) > (?, ?)", height, tokenId)
 		case p.Order == OrderAsc && orderBy == "token_id":
-			query = query.Where("(token_id, height) > (?, ?)", tokenId, height)
+			return query.Where("(token_id, height) > (?, ?)", tokenId, height)
 		}
-
 		return query.Order(p.OrderBy("token_id", "height")).Limit(p.Limit)
-
 	case CursorTypeHeight, CursorTypeOffset:
 		fallthrough
 	default:

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -78,7 +78,7 @@ func (h *NftHandler) getTokensWithFilters(
 // @Param account path string true "Account address"
 // @Param collection_addr query string false "Collection address to filter by (optional)"
 // @Param token_id query string false "Token ID to filter by (optional)"
-// @Param order_by query string false "Order by field (token_id, height)"
+// @Param order_by query string false "Order by field" Enums(token_id, height) default(token_id)
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
 // @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
@@ -147,7 +147,7 @@ func (h *NftHandler) GetTokensByAccount(c *fiber.Ctx) error {
 // @Produce json
 // @Param collection_addr path string true "Collection address"
 // @Param token_id query string false "Token ID to filter by (optional)"
-// @Param order_by query string false "Order by field (token_id, height)"
+// @Param order_by query string false "Order by field" Enums(token_id, height) default(token_id)
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
 // @Param pagination.limit query int false "Pagination limit, default is 100" default is 100

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -20,10 +20,10 @@ func normalizeOrderBy(orderBy string) (string, error) {
 		return "token_id", nil
 	}
 	switch v {
-	case "token_id", "timestamp":
+	case "token_id", "height":
 		return v, nil
 	default:
-		return "", fmt.Errorf("invalid order_by value '%s', must be one of: token_id, timestamp", orderBy)
+		return "", fmt.Errorf("invalid order_by value '%s', must be one of: token_id, height", orderBy)
 	}
 
 }
@@ -50,7 +50,7 @@ func (h *NftHandler) getTokensWithFilters(
 		orderClause := fmt.Sprintf("%s %s", orderBy, pagination.Order)
 		finalQuery = baseQuery.Order(orderClause).Offset(pagination.Offset).Limit(pagination.Limit)
 	} else {
-		finalQuery = pagination.ApplyToNft(baseQuery)
+		finalQuery = pagination.ApplyToNft(baseQuery, orderBy)
 	}
 
 	if err := finalQuery.Find(&nfts).Error; err != nil {

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -2,8 +2,10 @@ package nft
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 
 	"github.com/initia-labs/rollytics/api/handler/common"
 	"github.com/initia-labs/rollytics/types"
@@ -18,6 +20,7 @@ import (
 // @Param account path string true "Account address"
 // @Param collection_addr query string false "Collection address to filter by (optional)"
 // @Param token_id query string false "Token ID to filter by (optional)"
+// @Param order_by query string false "Order by field (token_id, timestamp)"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
 // @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
@@ -74,7 +77,15 @@ func (h *NftHandler) GetTokensByAccount(c *fiber.Ctx) error {
 	}
 
 	var nfts []types.CollectedNft
-	finalQuery := pagination.ApplyToNft(query)
+	var finalQuery *gorm.DB
+	orderBy := c.Query("order_by")
+	if orderBy != "" {
+		orderClause := fmt.Sprintf("%s %s", orderBy, pagination.Order)
+		finalQuery = query.Order(orderClause).Offset(pagination.Offset).Limit(pagination.Limit)
+	} else {
+		finalQuery = pagination.ApplyToNft(query)
+	}
+
 	if err := finalQuery.Find(&nfts).Error; err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}
@@ -108,6 +119,7 @@ func (h *NftHandler) GetTokensByAccount(c *fiber.Ctx) error {
 // @Produce json
 // @Param collection_addr path string true "Collection address"
 // @Param token_id query string false "Token ID to filter by (optional)"
+// @Param order_by query string false "Order by field (token_id, timestamp)"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
 // @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
@@ -145,7 +157,14 @@ func (h *NftHandler) GetTokensByCollectionAddr(c *fiber.Ctx) error {
 	}
 
 	var nfts []types.CollectedNft
-	finalQuery := pagination.ApplyToNft(query)
+	var finalQuery *gorm.DB
+	orderBy := c.Query("order_by")
+	if orderBy != "" {
+		orderClause := fmt.Sprintf("%s %s", orderBy, pagination.Order)
+		finalQuery = query.Order(orderClause).Offset(pagination.Offset).Limit(pagination.Limit)
+	} else {
+		finalQuery = pagination.ApplyToNft(query)
+	}
 	if err := finalQuery.Find(&nfts).Error; err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -25,7 +25,6 @@ func normalizeOrderBy(orderBy string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid order_by value '%s', must be one of: token_id, height", orderBy)
 	}
-
 }
 
 // getTokensWithFilters is a shared function that handles the common logic for fetching NFTs

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -45,15 +45,7 @@ func (h *NftHandler) getTokensWithFilters(
 	}
 
 	var nfts []types.CollectedNft
-	var finalQuery *gorm.DB
-	if orderBy != "" {
-		orderClause := fmt.Sprintf("%s %s", orderBy, pagination.Order)
-		finalQuery = baseQuery.Order(orderClause).Offset(pagination.Offset).Limit(pagination.Limit)
-	} else {
-		finalQuery = pagination.ApplyToNft(baseQuery, orderBy)
-	}
-
-	if err := finalQuery.Find(&nfts).Error; err != nil {
+	if err := pagination.ApplyToNft(baseQuery, orderBy).Find(&nfts).Error; err != nil {
 		return nil, err
 	}
 
@@ -87,7 +79,7 @@ func (h *NftHandler) getTokensWithFilters(
 // @Param account path string true "Account address"
 // @Param collection_addr query string false "Collection address to filter by (optional)"
 // @Param token_id query string false "Token ID to filter by (optional)"
-// @Param order_by query string false "Order by field (token_id, timestamp)"
+// @Param order_by query string false "Order by field (token_id, height)"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
 // @Param pagination.limit query int false "Pagination limit, default is 100" default is 100
@@ -156,7 +148,7 @@ func (h *NftHandler) GetTokensByAccount(c *fiber.Ctx) error {
 // @Produce json
 // @Param collection_addr path string true "Collection address"
 // @Param token_id query string false "Token ID to filter by (optional)"
-// @Param order_by query string false "Order by field (token_id, timestamp)"
+// @Param order_by query string false "Order by field (token_id, height)"
 // @Param pagination.key query string false "Pagination key"
 // @Param pagination.offset query int false "Pagination offset"
 // @Param pagination.limit query int false "Pagination limit, default is 100" default is 100

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -12,22 +12,16 @@ import (
 	"github.com/initia-labs/rollytics/types"
 )
 
-// validateOrderBy validates that the order_by parameter is one of the allowed values
-func validateOrderBy(orderBy string) error {
-	if orderBy == "" {
-		return nil // empty is allowed
+// normalizeOrderBy validates and returns a normalized (lowercased, trimmed) order_by.
+func normalizeOrderBy(orderBy string) (string, error) {
+	v := strings.ToLower(strings.TrimSpace(orderBy))
+	switch v {
+	case "token_id", "timestamp":
+		return v, nil
+	default:
+		return "", fmt.Errorf("invalid order_by value '%s', must be one of: token_id, timestamp", orderBy)
 	}
 
-	allowedValues := []string{"token_id", "timestamp"}
-	orderByLower := strings.ToLower(strings.TrimSpace(orderBy))
-
-	for _, allowed := range allowedValues {
-		if orderByLower == allowed {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("invalid order_by value '%s', must be one of: %s", orderBy, strings.Join(allowedValues, ", "))
 }
 
 // getTokensWithFilters is a shared function that handles the common logic for fetching NFTs
@@ -111,9 +105,8 @@ func (h *NftHandler) GetTokensByAccount(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
-	// Validate order_by parameter
-	orderBy := c.Query("order_by")
-	if err := validateOrderBy(orderBy); err != nil {
+	orderBy, err := normalizeOrderBy(c.Query("order_by"))
+	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
@@ -177,9 +170,8 @@ func (h *NftHandler) GetTokensByCollectionAddr(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
-	// Validate order_by parameter
-	orderBy := c.Query("order_by")
-	if err := validateOrderBy(orderBy); err != nil {
+	orderBy, err := normalizeOrderBy(c.Query("order_by"))
+	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 

--- a/api/handler/nft/token.go
+++ b/api/handler/nft/token.go
@@ -15,6 +15,10 @@ import (
 // normalizeOrderBy validates and returns a normalized (lowercased, trimmed) order_by.
 func normalizeOrderBy(orderBy string) (string, error) {
 	v := strings.ToLower(strings.TrimSpace(orderBy))
+	// default to token_id
+	if v == "" {
+		return "token_id", nil
+	}
 	switch v {
 	case "token_id", "timestamp":
 		return v, nil

--- a/api/handler/nft/token_test.go
+++ b/api/handler/nft/token_test.go
@@ -314,18 +314,13 @@ func TestValidateOrderBy(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "Valid timestamp order_by",
-			orderBy:   "timestamp",
+			name:      "Valid height order_by",
+			orderBy:   "height",
 			expectErr: false,
 		},
 		{
 			name:      "Case insensitive token_id",
 			orderBy:   "TOKEN_ID",
-			expectErr: false,
-		},
-		{
-			name:      "Case insensitive timestamp",
-			orderBy:   "TIMESTAMP",
 			expectErr: false,
 		},
 		{
@@ -342,25 +337,19 @@ func TestValidateOrderBy(t *testing.T) {
 			name:      "Invalid order_by value",
 			orderBy:   "invalid_field",
 			expectErr: true,
-			errMsg:    "invalid order_by value 'invalid_field', must be one of: token_id, timestamp",
-		},
-		{
-			name:      "Empty string with spaces",
-			orderBy:   "   ",
-			expectErr: true,
-			errMsg:    "invalid order_by value '   ', must be one of: token_id, timestamp",
+			errMsg:    "invalid order_by value 'invalid_field', must be one of: token_id, height",
 		},
 		{
 			name:      "Partial match should fail",
 			orderBy:   "token",
 			expectErr: true,
-			errMsg:    "invalid order_by value 'token', must be one of: token_id, timestamp",
+			errMsg:    "invalid order_by value 'token', must be one of: token_id, height",
 		},
 		{
 			name:      "Numeric value should fail",
 			orderBy:   "123",
 			expectErr: true,
-			errMsg:    "invalid order_by value '123', must be one of: token_id, timestamp",
+			errMsg:    "invalid order_by value '123', must be one of: token_id, height",
 		},
 	}
 
@@ -410,14 +399,14 @@ func TestGetTokensWithFilters_OrderByHandling(t *testing.T) {
 			description:   "Should construct proper ORDER BY clause",
 		},
 		{
-			name:    "timestamp order_by with ASC",
-			orderBy: "timestamp",
+			name:    "height order_by with ASC",
+			orderBy: "height",
 			pagination: &common.Pagination{
 				Limit:  10,
 				Offset: 0,
 				Order:  "ASC",
 			},
-			expectedOrder: "timestamp ASC",
+			expectedOrder: "height ASC",
 			description:   "Should construct proper ORDER BY clause with ASC",
 		},
 		{
@@ -471,15 +460,15 @@ func TestPaginationWithOrderBy(t *testing.T) {
 			description: "Should handle valid pagination with custom order",
 		},
 		{
-			name:    "Valid pagination with timestamp order",
-			orderBy: "timestamp",
+			name:    "Valid pagination with height order",
+			orderBy: "height",
 			pagination: &common.Pagination{
 				Limit:  50,
 				Offset: 25,
 				Order:  "ASC",
 			},
 			expectError: false,
-			description: "Should handle valid pagination with timestamp order",
+			description: "Should handle valid pagination with height order",
 		},
 		{
 			name:    "Empty order_by with pagination",
@@ -583,14 +572,14 @@ func TestOrderByWithPaginationScenarios(t *testing.T) {
 			expectedResult: "token_id DESC",
 		},
 		{
-			name:    "Second page with timestamp order",
-			orderBy: "timestamp",
+			name:    "Second page with height order",
+			orderBy: "height",
 			pagination: &common.Pagination{
 				Limit:  10,
 				Offset: 10,
 				Order:  "ASC",
 			},
-			expectedResult: "timestamp ASC",
+			expectedResult: "height ASC",
 		},
 		{
 			name:    "Large offset with token_id order",
@@ -654,7 +643,7 @@ func TestOrderByVsDefaultPagination(t *testing.T) {
 // Test that the allowed values are correctly defined
 func TestAllowedOrderByValues(t *testing.T) {
 	// Test that the allowed values in validateOrderBy match expected fields
-	allowedValues := []string{"token_id", "timestamp"}
+	allowedValues := []string{"token_id", "height"}
 
 	// These should be the only valid values
 	for _, value := range allowedValues {
@@ -669,7 +658,7 @@ func TestAllowedOrderByValues(t *testing.T) {
 	}
 
 	// Test that other common field names are not allowed
-	invalidValues := []string{"id", "height", "owner_id", "collection_addr", "uri", "created_at", "updated_at"}
+	invalidValues := []string{"id", "owner_id", "collection_addr", "uri", "created_at", "updated_at"}
 	for _, value := range invalidValues {
 		_, err := normalizeOrderBy(value)
 		assert.Error(t, err, "Value %s should not be valid", value)
@@ -689,7 +678,7 @@ func TestOrderByErrorMessage(t *testing.T) {
 
 	// Check that the error message contains the allowed values
 	assert.Contains(t, errorMsg, "token_id")
-	assert.Contains(t, errorMsg, "timestamp")
+	assert.Contains(t, errorMsg, "height")
 
 	// Check the format of the error message
 	expectedPrefix := fmt.Sprintf("invalid order_by value '%s', must be one of:", invalidValue)

--- a/api/handler/nft/token_test.go
+++ b/api/handler/nft/token_test.go
@@ -1,6 +1,8 @@
 package nft
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -291,4 +293,405 @@ func TestNft_CursorOrdering(t *testing.T) {
 	// Different height, same token_id
 	assert.NotEqual(t, cursor1["height"], cursor3["height"])
 	assert.Equal(t, cursor1["token_id"], cursor3["token_id"])
+}
+
+// Test validateOrderBy function
+func TestValidateOrderBy(t *testing.T) {
+	tests := []struct {
+		name      string
+		orderBy   string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name:      "Empty order_by should be valid",
+			orderBy:   "",
+			expectErr: false,
+		},
+		{
+			name:      "Valid token_id order_by",
+			orderBy:   "token_id",
+			expectErr: false,
+		},
+		{
+			name:      "Valid timestamp order_by",
+			orderBy:   "timestamp",
+			expectErr: false,
+		},
+		{
+			name:      "Case insensitive token_id",
+			orderBy:   "TOKEN_ID",
+			expectErr: false,
+		},
+		{
+			name:      "Case insensitive timestamp",
+			orderBy:   "TIMESTAMP",
+			expectErr: false,
+		},
+		{
+			name:      "Mixed case token_id",
+			orderBy:   "Token_Id",
+			expectErr: false,
+		},
+		{
+			name:      "Whitespace around valid value",
+			orderBy:   "  token_id  ",
+			expectErr: false,
+		},
+		{
+			name:      "Invalid order_by value",
+			orderBy:   "invalid_field",
+			expectErr: true,
+			errMsg:    "invalid order_by value 'invalid_field', must be one of: token_id, timestamp",
+		},
+		{
+			name:      "Empty string with spaces",
+			orderBy:   "   ",
+			expectErr: true,
+			errMsg:    "invalid order_by value '   ', must be one of: token_id, timestamp",
+		},
+		{
+			name:      "Partial match should fail",
+			orderBy:   "token",
+			expectErr: true,
+			errMsg:    "invalid order_by value 'token', must be one of: token_id, timestamp",
+		},
+		{
+			name:      "Numeric value should fail",
+			orderBy:   "123",
+			expectErr: true,
+			errMsg:    "invalid order_by value '123', must be one of: token_id, timestamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOrderBy(tt.orderBy)
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test getTokensWithFilters function behavior
+func TestGetTokensWithFilters_OrderByHandling(t *testing.T) {
+	// Test the order by clause construction logic
+	tests := []struct {
+		name          string
+		orderBy       string
+		pagination    *common.Pagination
+		expectedOrder string
+		description   string
+	}{
+		{
+			name:    "No order_by uses default pagination",
+			orderBy: "",
+			pagination: &common.Pagination{
+				Limit:  10,
+				Offset: 0,
+				Order:  "DESC",
+			},
+			expectedOrder: "",
+			description:   "When order_by is empty, should use pagination.ApplyToNft",
+		},
+		{
+			name:    "token_id order_by with DESC",
+			orderBy: "token_id",
+			pagination: &common.Pagination{
+				Limit:  10,
+				Offset: 0,
+				Order:  "DESC",
+			},
+			expectedOrder: "token_id DESC",
+			description:   "Should construct proper ORDER BY clause",
+		},
+		{
+			name:    "timestamp order_by with ASC",
+			orderBy: "timestamp",
+			pagination: &common.Pagination{
+				Limit:  10,
+				Offset: 0,
+				Order:  "ASC",
+			},
+			expectedOrder: "timestamp ASC",
+			description:   "Should construct proper ORDER BY clause with ASC",
+		},
+		{
+			name:    "token_id order_by with offset and limit",
+			orderBy: "token_id",
+			pagination: &common.Pagination{
+				Limit:  5,
+				Offset: 10,
+				Order:  "DESC",
+			},
+			expectedOrder: "token_id DESC",
+			description:   "Should apply offset and limit with custom order",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the order clause construction logic
+			var orderClause string
+			if tt.orderBy != "" {
+				orderClause = fmt.Sprintf("%s %s", tt.orderBy, tt.pagination.Order)
+			}
+
+			if tt.orderBy != "" {
+				assert.Equal(t, tt.expectedOrder, orderClause, tt.description)
+			} else {
+				assert.Empty(t, orderClause, tt.description)
+			}
+		})
+	}
+}
+
+// Test pagination integration with order_by
+func TestPaginationWithOrderBy(t *testing.T) {
+	tests := []struct {
+		name        string
+		orderBy     string
+		pagination  *common.Pagination
+		expectError bool
+		description string
+	}{
+		{
+			name:    "Valid pagination with token_id order",
+			orderBy: "token_id",
+			pagination: &common.Pagination{
+				Limit:  100,
+				Offset: 0,
+				Order:  "DESC",
+			},
+			expectError: false,
+			description: "Should handle valid pagination with custom order",
+		},
+		{
+			name:    "Valid pagination with timestamp order",
+			orderBy: "timestamp",
+			pagination: &common.Pagination{
+				Limit:  50,
+				Offset: 25,
+				Order:  "ASC",
+			},
+			expectError: false,
+			description: "Should handle valid pagination with timestamp order",
+		},
+		{
+			name:    "Empty order_by with pagination",
+			orderBy: "",
+			pagination: &common.Pagination{
+				Limit:  10,
+				Offset: 0,
+				Order:  "DESC",
+			},
+			expectError: false,
+			description: "Should handle empty order_by with default pagination",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Validate order_by parameter
+			err := validateOrderBy(tt.orderBy)
+			if tt.expectError {
+				assert.Error(t, err, tt.description)
+			} else {
+				assert.NoError(t, err, tt.description)
+			}
+
+			// Test pagination structure
+			assert.NotNil(t, tt.pagination)
+			assert.Greater(t, tt.pagination.Limit, 0)
+			assert.GreaterOrEqual(t, tt.pagination.Offset, 0)
+			assert.Contains(t, []string{"ASC", "DESC"}, tt.pagination.Order)
+		})
+	}
+}
+
+// Test order_by parameter edge cases
+func TestOrderByEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		orderBy   string
+		expectErr bool
+	}{
+		{
+			name:      "Null character",
+			orderBy:   "token_id\x00",
+			expectErr: true,
+		},
+		{
+			name:      "Unicode characters",
+			orderBy:   "token_ïd",
+			expectErr: true,
+		},
+		{
+			name:      "SQL injection attempt",
+			orderBy:   "token_id; DROP TABLE nft;",
+			expectErr: true,
+		},
+		{
+			name:      "Very long string",
+			orderBy:   strings.Repeat("a", 1000),
+			expectErr: true,
+		},
+		{
+			name:      "Special characters",
+			orderBy:   "token_id@#$%",
+			expectErr: true,
+		},
+		{
+			name:      "Numbers and letters",
+			orderBy:   "token_id123",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOrderBy(tt.orderBy)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test the integration of order_by with different pagination scenarios
+func TestOrderByWithPaginationScenarios(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		orderBy        string
+		pagination     *common.Pagination
+		expectedResult string
+	}{
+		{
+			name:    "First page with token_id order",
+			orderBy: "token_id",
+			pagination: &common.Pagination{
+				Limit:  10,
+				Offset: 0,
+				Order:  "DESC",
+			},
+			expectedResult: "token_id DESC",
+		},
+		{
+			name:    "Second page with timestamp order",
+			orderBy: "timestamp",
+			pagination: &common.Pagination{
+				Limit:  10,
+				Offset: 10,
+				Order:  "ASC",
+			},
+			expectedResult: "timestamp ASC",
+		},
+		{
+			name:    "Large offset with token_id order",
+			orderBy: "token_id",
+			pagination: &common.Pagination{
+				Limit:  50,
+				Offset: 1000,
+				Order:  "DESC",
+			},
+			expectedResult: "token_id DESC",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// Validate order_by
+			err := validateOrderBy(scenario.orderBy)
+			assert.NoError(t, err)
+
+			// Test order clause construction
+			orderClause := fmt.Sprintf("%s %s", scenario.orderBy, scenario.pagination.Order)
+			assert.Equal(t, scenario.expectedResult, orderClause)
+
+			// Test pagination values
+			assert.Greater(t, scenario.pagination.Limit, 0)
+			assert.GreaterOrEqual(t, scenario.pagination.Offset, 0)
+		})
+	}
+}
+
+// Test the behavior when order_by is used vs when it's not
+func TestOrderByVsDefaultPagination(t *testing.T) {
+	basePagination := &common.Pagination{
+		Limit:  10,
+		Offset: 0,
+		Order:  "DESC",
+	}
+
+	t.Run("With order_by uses custom ORDER BY clause", func(t *testing.T) {
+		orderBy := "token_id"
+		err := validateOrderBy(orderBy)
+		assert.NoError(t, err)
+
+		// Simulate the logic from getTokensWithFilters
+		orderClause := fmt.Sprintf("%s %s", orderBy, basePagination.Order)
+		expectedClause := "token_id DESC"
+		assert.Equal(t, expectedClause, orderClause)
+	})
+
+	t.Run("Without order_by uses pagination.ApplyToNft", func(t *testing.T) {
+		orderBy := ""
+		err := validateOrderBy(orderBy)
+		assert.NoError(t, err)
+
+		// When orderBy is empty, the function should use pagination.ApplyToNft
+		// This would apply the default ordering (height, token_id) with the pagination order
+		assert.Empty(t, orderBy)
+	})
+}
+
+// Test that the allowed values are correctly defined
+func TestAllowedOrderByValues(t *testing.T) {
+	// Test that the allowed values in validateOrderBy match expected fields
+	allowedValues := []string{"token_id", "timestamp"}
+
+	// These should be the only valid values
+	for _, value := range allowedValues {
+		err := validateOrderBy(value)
+		assert.NoError(t, err, "Value %s should be valid", value)
+	}
+
+	// Test case insensitive versions
+	for _, value := range allowedValues {
+		err := validateOrderBy(strings.ToUpper(value))
+		assert.NoError(t, err, "Value %s should be valid (case insensitive)", strings.ToUpper(value))
+	}
+
+	// Test that other common field names are not allowed
+	invalidValues := []string{"id", "height", "owner_id", "collection_addr", "uri", "created_at", "updated_at"}
+	for _, value := range invalidValues {
+		err := validateOrderBy(value)
+		assert.Error(t, err, "Value %s should not be valid", value)
+	}
+}
+
+// Test the error message format
+func TestOrderByErrorMessage(t *testing.T) {
+	invalidValue := "invalid_field"
+	err := validateOrderBy(invalidValue)
+
+	assert.Error(t, err)
+	errorMsg := err.Error()
+
+	// Check that the error message contains the invalid value
+	assert.Contains(t, errorMsg, invalidValue)
+
+	// Check that the error message contains the allowed values
+	assert.Contains(t, errorMsg, "token_id")
+	assert.Contains(t, errorMsg, "timestamp")
+
+	// Check the format of the error message
+	expectedPrefix := fmt.Sprintf("invalid order_by value '%s', must be one of:", invalidValue)
+	assert.True(t, strings.HasPrefix(errorMsg, expectedPrefix))
 }

--- a/api/handler/nft/token_test.go
+++ b/api/handler/nft/token_test.go
@@ -366,7 +366,7 @@ func TestValidateOrderBy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOrderBy(tt.orderBy)
+			_, err := normalizeOrderBy(tt.orderBy)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)
@@ -497,7 +497,7 @@ func TestPaginationWithOrderBy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Validate order_by parameter
-			err := validateOrderBy(tt.orderBy)
+			_, err := normalizeOrderBy(tt.orderBy)
 			if tt.expectError {
 				assert.Error(t, err, tt.description)
 			} else {
@@ -554,7 +554,7 @@ func TestOrderByEdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOrderBy(tt.orderBy)
+			_, err := normalizeOrderBy(tt.orderBy)
 			if tt.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -607,7 +607,7 @@ func TestOrderByWithPaginationScenarios(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			// Validate order_by
-			err := validateOrderBy(scenario.orderBy)
+			_, err := normalizeOrderBy(scenario.orderBy)
 			assert.NoError(t, err)
 
 			// Test order clause construction
@@ -631,7 +631,7 @@ func TestOrderByVsDefaultPagination(t *testing.T) {
 
 	t.Run("With order_by uses custom ORDER BY clause", func(t *testing.T) {
 		orderBy := "token_id"
-		err := validateOrderBy(orderBy)
+		_, err := normalizeOrderBy(orderBy)
 		assert.NoError(t, err)
 
 		// Simulate the logic from getTokensWithFilters
@@ -642,7 +642,7 @@ func TestOrderByVsDefaultPagination(t *testing.T) {
 
 	t.Run("Without order_by uses pagination.ApplyToNft", func(t *testing.T) {
 		orderBy := ""
-		err := validateOrderBy(orderBy)
+		_, err := normalizeOrderBy(orderBy)
 		assert.NoError(t, err)
 
 		// When orderBy is empty, the function should use pagination.ApplyToNft
@@ -658,20 +658,20 @@ func TestAllowedOrderByValues(t *testing.T) {
 
 	// These should be the only valid values
 	for _, value := range allowedValues {
-		err := validateOrderBy(value)
+		_, err := normalizeOrderBy(value)
 		assert.NoError(t, err, "Value %s should be valid", value)
 	}
 
 	// Test case insensitive versions
 	for _, value := range allowedValues {
-		err := validateOrderBy(strings.ToUpper(value))
+		_, err := normalizeOrderBy(strings.ToUpper(value))
 		assert.NoError(t, err, "Value %s should be valid (case insensitive)", strings.ToUpper(value))
 	}
 
 	// Test that other common field names are not allowed
 	invalidValues := []string{"id", "height", "owner_id", "collection_addr", "uri", "created_at", "updated_at"}
 	for _, value := range invalidValues {
-		err := validateOrderBy(value)
+		_, err := normalizeOrderBy(value)
 		assert.Error(t, err, "Value %s should not be valid", value)
 	}
 }
@@ -679,7 +679,7 @@ func TestAllowedOrderByValues(t *testing.T) {
 // Test the error message format
 func TestOrderByErrorMessage(t *testing.T) {
 	invalidValue := "invalid_field"
-	err := validateOrderBy(invalidValue)
+	_, err := normalizeOrderBy(invalidValue)
 
 	assert.Error(t, err)
 	errorMsg := err.Error()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added order_by query parameter to NFT listing endpoints (by account, by collection) to sort results by token_id or height; pagination and cursors respect the chosen sort and order.

- Documentation
  - API docs and Swagger updated with the new order_by parameter, allowed values (token_id, height), and default (token_id).

- Tests
  - Added extensive tests for order_by validation, sorting behavior, pagination integration, edge cases, and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->