### PR TITLE
chore: omit internal_tx_height on status

### DIFF
--- a/api/handler/status/types.go
+++ b/api/handler/status/types.go
@@ -5,5 +5,5 @@ type StatusResponse struct {
 	CommitHash       string `json:"commit_hash" extensions:"x-order:1"`
 	ChainId          string `json:"chain_id" extensions:"x-order:2"`
 	Height           int64  `json:"height" extensions:"x-order:3"`
-	InternalTxHeight int64  `json:"internal_tx_height" extensions:"x-order:4"`
+	InternalTxHeight int64  `json:"internal_tx_height,omitempty" extensions:"x-order:4"`
 }


### PR DESCRIPTION
we don't have to show internal_tx_height on `/status` for non-evm rollups and internal tx indexing disabled minievm based rollups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status API responses are cleaner: the internal transaction height is now omitted when not applicable (zero value). This reduces unnecessary fields in the payload and improves readability.
  * API clients should handle cases where this field may be absent. If your integration relied on the field always being present, update parsing to treat a missing value as zero/default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->