### PR TITLE
fix(api): nft order_by error

### DIFF
--- a/api/handler/common/pagination.go
+++ b/api/handler/common/pagination.go
@@ -83,6 +83,11 @@ func ParsePagination(c *fiber.Ctx) (*Pagination, error) {
 	key := c.Query("pagination.key")
 	offset := c.QueryInt("pagination.offset", DefaultOffset)
 
+	// Validate offset is not negative
+	if offset < 0 {
+		return nil, errors.New("pagination.offset cannot be negative")
+	}
+
 	pagination := &Pagination{
 		Limit:      limit,
 		Offset:     offset,


### PR DESCRIPTION
test done with both of order_by value on local machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevented negative pagination offsets causing errors.
  - Improved NFT list pagination to prevent missing or duplicate items when navigating.
  - Ensured consistent secondary sorting, reducing unexpected reordering across pages.
  - More reliable ordering when sorting by token ID or block height.

- Refactor
  - Streamlined pagination logic for NFTs, centralizing fallback behavior for stable results.
  - Stricter handling of composite cursor data to avoid edge-case inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->