### PR TITLE
perf(nft): add 2 composite indices on nft to improve query performance

### DIFF
--- a/orm/migrations/20250916112051_add_nft_indices.sql
+++ b/orm/migrations/20250916112051_add_nft_indices.sql
@@ -1,0 +1,4 @@
+-- Create index "nft_height_token_id" to table: "nft"
+CREATE INDEX "nft_height_token_id" ON "public"."nft" ("height", "token_id");
+-- Create index "nft_token_id_height" to table: "nft"
+CREATE INDEX "nft_token_id_height" ON "public"."nft" ("token_id", "height");

--- a/orm/migrations/atlas.sum
+++ b/orm/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:aJTGpdJmPt3KMXYCBaSE0F8ir0D7UivCKqYvA471ATs=
+h1:33V5nEpf1OmluHR7KfcyaMv4O/DZe9tLGaAkHDMniEE=
 20250806084521_migration.sql h1:Qdn42AgebdtLQoc+aUfautynU10/oHxL8wjXusSqQaE=
 20250822034114_migration.sql h1:ybJSC6AlidSpXS+oup6aYHchZFaOEkJU9C8lOnF0S68=
 20250902111542_add_partial_indices.sql h1:Qc5PA4bCNP5tjhZrHFhscgc/Ap/Ee/mnmoPixefeRtw=
+20250916112051_add_nft_indices.sql h1:CDtNH9rxcFQpR9uRQD1AdFxoTxWiYXsCTCgoLJ4E1c0=

--- a/types/table.go
+++ b/types/table.go
@@ -85,9 +85,9 @@ type CollectedNftCollection struct {
 
 type CollectedNft struct {
 	CollectionAddr []byte    `gorm:"type:bytea;primaryKey"`
-	TokenId        string    `gorm:"type:text;primaryKey;index:nft_token_id"`
+	TokenId        string    `gorm:"type:text;primaryKey;index:nft_token_id;index:nft_token_id_height,priority:1;index:nft_height_token_id,priority:2"`
 	Addr           []byte    `gorm:"type:bytea;index:nft_addr,type:hash"` // only used in move // hex address
-	Height         int64     `gorm:"type:bigint;index:nft_height"`
+	Height         int64     `gorm:"type:bigint;index:nft_height;index:nft_token_id_height,priority:2;index:nft_height_token_id,priority:1"`
 	Timestamp      time.Time `gorm:"type:timestamptz"`
 	OwnerId        int64     `gorm:"type:bigint;index:nft_owner_id"`
 	Uri            string    `gorm:"type:text"`


### PR DESCRIPTION
to improve query performance on nft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Improved performance for NFT-related pages (lists, filters, detail views, and pagination) by introducing optimized composite database indexes, significantly reducing query latency and speeding up data loading, especially under large datasets and high traffic.
- Chores
  - Added a database migration to apply the new indexes automatically during deployment, ensuring consistent performance improvements without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->