### PR TITLE
fix(api): don't leave 0x if nft object/collection is empty

### DIFF
--- a/api/handler/nft/tx.go
+++ b/api/handler/nft/tx.go
@@ -88,7 +88,7 @@ func (h *NftHandler) GetNftTxs(c *fiber.Ctx) error {
 
 	case types.WasmVM, types.EVM:
 		nftKey := util.NftKey{
-			CollectionAddr: util.BytesToHexWithPrefix(nft.CollectionAddr),
+			CollectionAddr: util.BytesToHexWithPrefixIfPresent(nft.CollectionAddr),
 			TokenId:        nft.TokenId,
 		}
 		nftIds, err := h.GetNftIds([]util.NftKey{nftKey})

--- a/api/handler/nft/types.go
+++ b/api/handler/nft/types.go
@@ -42,7 +42,7 @@ type CollectionResponse struct {
 
 func ToCollectionResponse(col types.CollectedNftCollection, creatorAccount []byte) Collection {
 	return Collection{
-		Address: util.BytesToHexWithPrefix(col.Addr),
+		Address: util.BytesToHexWithPrefixIfPresent(col.Addr),
 		CollectionDetail: CollectionDetail{
 			Creator:    sdk.AccAddress(creatorAccount).String(),
 			Name:       col.Name,
@@ -108,7 +108,7 @@ func ToNftsResponse(db *orm.Database, nfts []types.CollectedNft, ownerAccounts m
 	nftResponses := make([]Nft, 0, len(nfts))
 	for _, nft := range nfts {
 		// get collection names and origin names
-		collection, err := getCollectionByAddr(db, util.BytesToHexWithPrefix(nft.CollectionAddr))
+		collection, err := getCollectionByAddr(db, util.BytesToHexWithPrefixIfPresent(nft.CollectionAddr))
 		if err != nil {
 			return nil, err
 		}

--- a/api/handler/nft/types.go
+++ b/api/handler/nft/types.go
@@ -90,10 +90,10 @@ type NftsResponse struct {
 
 func ToNftResponse(name, originName string, nft types.CollectedNft, ownerAccount []byte) Nft {
 	return Nft{
-		CollectionAddr:       util.BytesToHexWithPrefix(nft.CollectionAddr),
+		CollectionAddr:       util.BytesToHexWithPrefixIfPresent(nft.CollectionAddr),
 		CollectionName:       name,
 		CollectionOriginName: originName,
-		ObjectAddr:           util.BytesToHexWithPrefix(nft.Addr), // only used in Move
+		ObjectAddr:           util.BytesToHexWithPrefixIfPresent(nft.Addr), // only used in Move
 		Owner:                sdk.AccAddress(ownerAccount).String(),
 		Nft: NftDetails{
 			TokenId: nft.TokenId,

--- a/util/util.go
+++ b/util/util.go
@@ -49,3 +49,10 @@ func BytesToHex(b []byte) string {
 func BytesToHexWithPrefix(b []byte) string {
 	return "0x" + hex.EncodeToString(b)
 }
+
+func BytesToHexWithPrefixIfPresent(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return "0x" + hex.EncodeToString(b)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Empty/missing NFT address fields now return an empty string instead of a standalone "0x".
  - Non-empty addresses continue to include the "0x" prefix.
  - This change applies to collection and object address fields (including addresses used for collection lookups); no other response fields, structures, or error behaviors were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->