### PR TITLE
fix: use subquery count

### DIFF
--- a/api/handler/common/pagination.go
+++ b/api/handler/common/pagination.go
@@ -252,29 +252,6 @@ func (p *Pagination) ToResponseWithLastRecord(total int64, lastRecord any) Pagin
 	return p.ToResponse(total)
 }
 
-// Query application methods for each table type
-func (p *Pagination) ApplyToEvmInternalTx(query *gorm.DB) *gorm.DB {
-	switch p.CursorType {
-	case CursorTypeSequence:
-		sequence, err := p.safeGetInt64("sequence")
-		if err != nil {
-			// Fallback to offset-based pagination on error
-			return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-		}
-		if p.Order == OrderDesc {
-			query = query.Where("sequence < ?", sequence)
-		} else {
-			query = query.Where("sequence > ?", sequence)
-		}
-		return query.Order(p.OrderBy("sequence")).Limit(p.Limit)
-
-	case CursorTypeOffset:
-		fallthrough
-	default:
-		return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-	}
-}
-
 func (p *Pagination) ApplyToNftCollection(query *gorm.DB) *gorm.DB {
 	switch p.CursorType {
 	case CursorTypeHeight:
@@ -352,51 +329,6 @@ func (p *Pagination) ApplyToNft(query *gorm.DB, orderBy string) *gorm.DB {
 	}
 }
 
-// Additional Apply methods for other table types
-func (p *Pagination) ApplyToTx(query *gorm.DB) *gorm.DB {
-	switch p.CursorType {
-	case CursorTypeSequence:
-		sequence, err := p.safeGetInt64("sequence")
-		if err != nil {
-			// Fallback to offset-based pagination on error
-			return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-		}
-		if p.Order == OrderDesc {
-			query = query.Where("sequence < ?", sequence)
-		} else {
-			query = query.Where("sequence > ?", sequence)
-		}
-		return query.Order(p.OrderBy("sequence")).Limit(p.Limit)
-
-	case CursorTypeOffset:
-		fallthrough
-	default:
-		return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-	}
-}
-
-func (p *Pagination) ApplyToEvmTx(query *gorm.DB) *gorm.DB {
-	switch p.CursorType {
-	case CursorTypeSequence:
-		sequence, err := p.safeGetInt64("sequence")
-		if err != nil {
-			// Fallback to offset-based pagination on error
-			return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-		}
-		if p.Order == OrderDesc {
-			query = query.Where("sequence < ?", sequence)
-		} else {
-			query = query.Where("sequence > ?", sequence)
-		}
-		return query.Order(p.OrderBy("sequence")).Limit(p.Limit)
-
-	case CursorTypeOffset:
-		fallthrough
-	default:
-		return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-	}
-}
-
 func (p *Pagination) ApplyToBlock(query *gorm.DB) *gorm.DB {
 	switch p.CursorType {
 	case CursorTypeHeight:
@@ -419,58 +351,12 @@ func (p *Pagination) ApplyToBlock(query *gorm.DB) *gorm.DB {
 	}
 }
 
-// Filtered Apply methods (with additional WHERE conditions)
-func (p *Pagination) ApplyToEvmInternalTxWithFilter(query *gorm.DB) *gorm.DB {
-	// Maintains existing filter conditions and adds cursor
+// ApplySequence applies sequence-based pagination to the given GORM query
+func (p *Pagination) ApplySequence(query *gorm.DB) *gorm.DB {
 	switch p.CursorType {
 	case CursorTypeSequence:
 		sequence, err := p.safeGetInt64("sequence")
 		if err != nil {
-			// Fallback to offset-based pagination on error
-			return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-		}
-		if p.Order == OrderDesc {
-			query = query.Where("sequence < ?", sequence)
-		} else {
-			query = query.Where("sequence > ?", sequence)
-		}
-		return query.Order(p.OrderBy("sequence")).Limit(p.Limit)
-
-	case CursorTypeOffset:
-		fallthrough
-	default:
-		return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-	}
-}
-
-func (p *Pagination) ApplyToTxWithFilter(query *gorm.DB) *gorm.DB {
-	switch p.CursorType {
-	case CursorTypeSequence:
-		sequence, err := p.safeGetInt64("sequence")
-		if err != nil {
-			// Fallback to offset-based pagination on error
-			return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-		}
-		if p.Order == OrderDesc {
-			query = query.Where("sequence < ?", sequence)
-		} else {
-			query = query.Where("sequence > ?", sequence)
-		}
-		return query.Order(p.OrderBy("sequence")).Limit(p.Limit)
-
-	case CursorTypeOffset:
-		fallthrough
-	default:
-		return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
-	}
-}
-
-func (p *Pagination) ApplyToEvmTxWithFilter(query *gorm.DB) *gorm.DB {
-	switch p.CursorType {
-	case CursorTypeSequence:
-		sequence, err := p.safeGetInt64("sequence")
-		if err != nil {
-			// Fallback to offset-based pagination on error
 			return query.Order(p.OrderBy("sequence")).Offset(p.Offset).Limit(p.Limit)
 		}
 		if p.Order == OrderDesc {

--- a/api/handler/tx/edge_tables_test.go
+++ b/api/handler/tx/edge_tables_test.go
@@ -217,11 +217,11 @@ func TestGetTxsByHeight_EdgePathWithMsgFilter(t *testing.T) {
 	mock.ExpectQuery(`SELECT \* FROM "seq_info" WHERE name = \$1 ORDER BY`).
 		WithArgs(string(types.SeqInfoTxEdgeBackfill), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"name", "sequence"}).AddRow(string(types.SeqInfoTxEdgeBackfill), int64(-1)))
-	mock.ExpectQuery(`SELECT count\(\*\) FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT`).
-		WithArgs(height, sqlmock.AnyArg()).
+	mock.ExpectQuery(`SELECT COUNT\(DISTINCT\("sequence"\)\) FROM "` + types.CollectedTxMsgType{}.TableName() + `" WHERE msg_type_id = ANY`).
+		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT`).
-		WithArgs(height, sqlmock.AnyArg(), 100).
+		WithArgs(height, sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(row)
 	mock.ExpectRollback()
 

--- a/api/handler/tx/edge_tables_test.go
+++ b/api/handler/tx/edge_tables_test.go
@@ -179,7 +179,7 @@ func TestGetTxs_EdgePathWithMsgFilter(t *testing.T) {
 	mock.ExpectQuery(`SELECT COUNT\(DISTINCT\("sequence"\)\) FROM "` + types.CollectedTxMsgType{}.TableName() + `" WHERE msg_type_id = ANY`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE sequence IN \(SELECT DISTINCT`).
+	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE sequence IN \(SELECT DISTINCT \"sequence\" FROM \"tx_msg_types\" WHERE msg_type_id = ANY\(\$1\) ORDER BY sequence DESC LIMIT \$2\)`).
 		WithArgs(sqlmock.AnyArg(), int64(common.DefaultLimit)).
 		WillReturnRows(row)
 	mock.ExpectRollback()
@@ -222,7 +222,7 @@ func TestGetTxs_EdgePathWithMsgFilter_CustomLimit(t *testing.T) {
 	mock.ExpectQuery(`SELECT COUNT\(DISTINCT\("sequence"\)\) FROM "` + types.CollectedTxMsgType{}.TableName() + `" WHERE msg_type_id = ANY`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE sequence IN \(SELECT DISTINCT`).
+	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE sequence IN \(SELECT DISTINCT \"sequence\" FROM \"tx_msg_types\" WHERE msg_type_id = ANY\(\$1\) ORDER BY sequence DESC LIMIT \$2\)`).
 		WithArgs(sqlmock.AnyArg(), int64(limit)).
 		WillReturnRows(row)
 	mock.ExpectRollback()
@@ -264,7 +264,7 @@ func TestGetTxsByHeight_EdgePathWithMsgFilter(t *testing.T) {
 	mock.ExpectQuery(`SELECT COUNT\(DISTINCT\("sequence"\)\) FROM "` + types.CollectedTxMsgType{}.TableName() + `" WHERE msg_type_id = ANY`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT`).
+	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT \"sequence\" FROM \"tx_msg_types\" WHERE msg_type_id = ANY\(\$2\)\) ORDER BY sequence DESC LIMIT \$3`).
 		WithArgs(height, sqlmock.AnyArg(), int64(common.DefaultLimit)).
 		WillReturnRows(row)
 	mock.ExpectRollback()
@@ -308,7 +308,7 @@ func TestGetTxsByHeight_EdgePathWithMsgFilter_CustomLimit(t *testing.T) {
 	mock.ExpectQuery(`SELECT COUNT\(DISTINCT\("sequence"\)\) FROM "` + types.CollectedTxMsgType{}.TableName() + `" WHERE msg_type_id = ANY`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT`).
+	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT \"sequence\" FROM \"tx_msg_types\" WHERE msg_type_id = ANY\(\$2\)\) ORDER BY sequence DESC LIMIT \$3`).
 		WithArgs(height, sqlmock.AnyArg(), int64(limit)).
 		WillReturnRows(row)
 	mock.ExpectRollback()

--- a/api/handler/tx/edge_tables_test.go
+++ b/api/handler/tx/edge_tables_test.go
@@ -261,8 +261,8 @@ func TestGetTxsByHeight_EdgePathWithMsgFilter(t *testing.T) {
 	mock.ExpectQuery(`SELECT \* FROM "seq_info" WHERE name = \$1 ORDER BY`).
 		WithArgs(string(types.SeqInfoTxEdgeBackfill), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"name", "sequence"}).AddRow(string(types.SeqInfoTxEdgeBackfill), int64(-1)))
-	mock.ExpectQuery(`SELECT COUNT\(DISTINCT\("sequence"\)\) FROM "` + types.CollectedTxMsgType{}.TableName() + `" WHERE msg_type_id = ANY`).
-		WithArgs(sqlmock.AnyArg()).
+	mock.ExpectQuery(`SELECT count\(\*\) FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT "sequence" FROM "`+types.CollectedTxMsgType{}.TableName()+`" WHERE msg_type_id = ANY\(\$2\)\)`).
+		WithArgs(height, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT \"sequence\" FROM \"tx_msg_types\" WHERE msg_type_id = ANY\(\$2\)\) ORDER BY sequence DESC LIMIT \$3`).
 		WithArgs(height, sqlmock.AnyArg(), int64(common.DefaultLimit)).
@@ -305,8 +305,8 @@ func TestGetTxsByHeight_EdgePathWithMsgFilter_CustomLimit(t *testing.T) {
 	mock.ExpectQuery(`SELECT \* FROM "seq_info" WHERE name = \$1 ORDER BY`).
 		WithArgs(string(types.SeqInfoTxEdgeBackfill), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"name", "sequence"}).AddRow(string(types.SeqInfoTxEdgeBackfill), int64(-1)))
-	mock.ExpectQuery(`SELECT COUNT\(DISTINCT\("sequence"\)\) FROM "` + types.CollectedTxMsgType{}.TableName() + `" WHERE msg_type_id = ANY`).
-		WithArgs(sqlmock.AnyArg()).
+	mock.ExpectQuery(`SELECT count\(\*\) FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT "sequence" FROM "`+types.CollectedTxMsgType{}.TableName()+`" WHERE msg_type_id = ANY\(\$2\)\)`).
+		WithArgs(height, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery(`SELECT \* FROM "tx" WHERE height = \$1 AND sequence IN \(SELECT DISTINCT \"sequence\" FROM \"tx_msg_types\" WHERE msg_type_id = ANY\(\$2\)\) ORDER BY sequence DESC LIMIT \$3`).
 		WithArgs(height, sqlmock.AnyArg(), int64(limit)).
@@ -386,7 +386,6 @@ func TestGetTxs_NoFilterLegacyPath(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT COALESCE\(MAX\(sequence\), 0\) FROM "tx"`).
 		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(sequence))
-
 	mock.ExpectQuery(`SELECT \* FROM "tx" ORDER BY sequence DESC LIMIT`).
 		WithArgs(100).
 		WillReturnRows(row)

--- a/api/handler/tx/evmtx.go
+++ b/api/handler/tx/evmtx.go
@@ -173,7 +173,8 @@ func buildEvmTxEdgeQuery(tx *gorm.DB, accountID int64, isSigner bool, pagination
 	sequenceQuery = pagination.ApplySequence(sequenceQuery)
 
 	query := tx.Model(&types.CollectedEvmTx{}).
-		Where("sequence IN (?)", sequenceQuery)
+		Where("sequence IN (?)", sequenceQuery).
+		Order(pagination.OrderBy("sequence"))
 
 	return query, total, nil
 }

--- a/api/handler/tx/internaltx.go
+++ b/api/handler/tx/internaltx.go
@@ -179,7 +179,8 @@ func buildEvmInternalTxEdgeQuery(tx *gorm.DB, accountID int64, pagination *commo
 	sequenceQuery = pagination.ApplySequence(sequenceQuery)
 
 	query := tx.Model(&types.CollectedEvmInternalTx{}).
-		Where("sequence IN (?)", sequenceQuery)
+		Where("sequence IN (?)", sequenceQuery).
+		Order(pagination.OrderBy("sequence"))
 
 	return query, total, nil
 }

--- a/api/handler/tx/query_helpers.go
+++ b/api/handler/tx/query_helpers.go
@@ -1,0 +1,110 @@
+package tx
+
+import (
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+
+	"github.com/initia-labs/rollytics/api/handler/common"
+	"github.com/initia-labs/rollytics/types"
+)
+
+func buildEdgeQueryForGetTxs(tx *gorm.DB, msgTypeIds []int64) (*gorm.DB, int64, error) {
+	sequenceQuery := tx.
+		Model(&types.CollectedTxMsgType{}).
+		Select("sequence")
+
+	if len(msgTypeIds) > 0 {
+		sequenceQuery = sequenceQuery.Where("msg_type_id = ANY(?)", pq.Array(msgTypeIds))
+	}
+
+	sequenceQuery = sequenceQuery.Distinct("sequence")
+	countQuery := sequenceQuery.Session(&gorm.Session{})
+
+	var total int64
+	if err := countQuery.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query := tx.Model(&types.CollectedTx{}).
+		Where("sequence IN (?)", sequenceQuery)
+
+	return query, total, nil
+}
+
+func buildEdgeQueryForGetTxsByHeight(tx *gorm.DB, height int64, msgTypeIds []int64) (*gorm.DB, int64, error) {
+	sequenceQuery := tx.
+		Model(&types.CollectedTxMsgType{}).
+		Select("sequence")
+
+	if len(msgTypeIds) > 0 {
+		sequenceQuery = sequenceQuery.Where("msg_type_id = ANY(?)", pq.Array(msgTypeIds))
+	}
+
+	sequenceQuery = sequenceQuery.Distinct("sequence")
+
+	baseQuery := tx.Model(&types.CollectedTx{}).
+		Where("height = ?", height).
+		Where("sequence IN (?)", sequenceQuery)
+
+	var total int64
+	if err := baseQuery.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return baseQuery, total, nil
+}
+
+func buildTxEdgeQuery(tx *gorm.DB, accountID int64, isSigner bool, msgTypeIds []int64) (*gorm.DB, int64, error) {
+	sequenceQuery := tx.
+		Model(&types.CollectedTxAccount{}).
+		Select("sequence").
+		Where("account_id = ?", accountID)
+
+	if isSigner {
+		sequenceQuery = sequenceQuery.Where("signer")
+	}
+
+	if len(msgTypeIds) > 0 {
+		at := types.CollectedTxAccount{}.TableName()
+		mtt := types.CollectedTxMsgType{}.TableName()
+		sequenceQuery = sequenceQuery.
+			Joins("JOIN "+mtt+" ON "+mtt+".sequence = "+at+".sequence").
+			Where(mtt+".msg_type_id = ANY(?)", pq.Array(msgTypeIds))
+	}
+
+	sequenceQuery = sequenceQuery.Distinct("sequence")
+	countQuery := sequenceQuery.Session(&gorm.Session{})
+
+	var total int64
+	if err := countQuery.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query := tx.Model(&types.CollectedTx{}).
+		Where("sequence IN (?)", sequenceQuery)
+
+	return query, total, nil
+}
+
+func buildTxLegacyQuery(tx *gorm.DB, accountIds []int64, isSigner bool, msgTypeIds []int64) (*gorm.DB, int64, error) {
+	query := tx.Model(&types.CollectedTx{}).
+		Where("account_ids && ?", pq.Array(accountIds))
+
+	if isSigner {
+		query = query.Where("signer_id = ?", accountIds[0])
+	}
+
+	if len(msgTypeIds) > 0 {
+		query = query.Where("msg_type_ids && ?", pq.Array(msgTypeIds))
+	}
+
+	var strategy types.CollectedTx
+	const hasFilters = true // always filtering by account_ids
+
+	total, err := common.GetOptimizedCount(query, strategy, hasFilters)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return query, total, nil
+}

--- a/api/handler/tx/tx.go
+++ b/api/handler/tx/tx.go
@@ -204,84 +204,6 @@ func (h *TxHandler) GetTxsByAccount(c *fiber.Ctx) error {
 	})
 }
 
-func buildEdgeQueryForGetTxs(tx *gorm.DB, msgTypeIds []int64) (*gorm.DB, int64, error) {
-	sequenceQuery := tx.
-		Model(&types.CollectedTxMsgType{}).
-		Select("sequence")
-
-	if len(msgTypeIds) > 0 {
-		sequenceQuery = sequenceQuery.Where("msg_type_id = ANY(?)", pq.Array(msgTypeIds))
-	}
-
-	sequenceQuery = sequenceQuery.Distinct("sequence")
-	countQuery := sequenceQuery.Session(&gorm.Session{})
-
-	var total int64
-	if err := countQuery.Count(&total).Error; err != nil {
-		return nil, 0, err
-	}
-
-	query := tx.Model(&types.CollectedTx{}).
-		Where("sequence IN (?)", sequenceQuery)
-
-	return query, total, nil
-}
-
-func buildTxEdgeQuery(tx *gorm.DB, accountID int64, isSigner bool, msgTypeIds []int64) (*gorm.DB, int64, error) {
-	sequenceQuery := tx.
-		Model(&types.CollectedTxAccount{}).
-		Select("sequence").
-		Where("account_id = ?", accountID)
-
-	if isSigner {
-		sequenceQuery = sequenceQuery.Where("signer")
-	}
-
-	if len(msgTypeIds) > 0 {
-		at := types.CollectedTxAccount{}.TableName()
-		mtt := types.CollectedTxMsgType{}.TableName()
-		sequenceQuery = sequenceQuery.
-			Joins("JOIN "+mtt+" ON "+mtt+".sequence = "+at+".sequence").
-			Where(mtt+".msg_type_id = ANY(?)", pq.Array(msgTypeIds))
-	}
-
-	sequenceQuery = sequenceQuery.Distinct("sequence")
-	countQuery := sequenceQuery.Session(&gorm.Session{})
-
-	var total int64
-	if err := countQuery.Count(&total).Error; err != nil {
-		return nil, 0, err
-	}
-
-	query := tx.Model(&types.CollectedTx{}).
-		Where("sequence IN (?)", sequenceQuery)
-
-	return query, total, nil
-}
-
-func buildTxLegacyQuery(tx *gorm.DB, accountIds []int64, isSigner bool, msgTypeIds []int64) (*gorm.DB, int64, error) {
-	query := tx.Model(&types.CollectedTx{}).
-		Where("account_ids && ?", pq.Array(accountIds))
-
-	if isSigner {
-		query = query.Where("signer_id = ?", accountIds[0])
-	}
-
-	if len(msgTypeIds) > 0 {
-		query = query.Where("msg_type_ids && ?", pq.Array(msgTypeIds))
-	}
-
-	var strategy types.CollectedTx
-	const hasFilters = true // always filtering by account_ids
-
-	total, err := common.GetOptimizedCount(query, strategy, hasFilters)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return query, total, nil
-}
-
 // GetTxsByHeight handles GET /tx/v1/txs/by_height/{height}
 // @Summary Get transactions by height
 // @Description Get transactions at a specific block height
@@ -310,23 +232,44 @@ func (h *TxHandler) GetTxsByHeight(c *fiber.Ctx) error {
 	tx := h.GetDatabase().Begin(&sql.TxOptions{ReadOnly: true})
 	defer tx.Rollback()
 
+	hasFilters := true // always has height filter
 	query := tx.Model(&types.CollectedTx{}).Where("height = ?", height)
 
-	hasFilters := true // always has height filter
+	var (
+		msgTypeIds []int64
+		total      int64
+	)
+
+	useEdges := false
 	if len(msgs) > 0 {
-		msgTypeIds, err := h.GetMsgTypeIds(msgs)
+		msgTypeIds, err = h.GetMsgTypeIds(msgs)
 		if err != nil {
 			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 		}
-		query = query.Where("msg_type_ids && ?", pq.Array(msgTypeIds))
+
+		useEdges, err = common.IsEdgeBackfillReady(tx, types.SeqInfoTxEdgeBackfill)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+		}
 	}
 
-	// Use optimized COUNT - always has filters (height + optional msgs)
-	var strategy types.CollectedTx
-	var total int64
-	total, err = common.GetOptimizedCount(query, strategy, hasFilters)
-	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	if useEdges {
+		var edgeErr error
+		query, total, edgeErr = buildEdgeQueryForGetTxsByHeight(tx, height, msgTypeIds)
+		if edgeErr != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, edgeErr.Error())
+		}
+	} else {
+		if len(msgs) > 0 {
+			query = query.Where("msg_type_ids && ?", pq.Array(msgTypeIds))
+		}
+
+		// Use optimized COUNT - always has filters (height + optional msgs)
+		var strategy types.CollectedTx
+		total, err = common.GetOptimizedCount(query, strategy, hasFilters)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+		}
 	}
 
 	var txs []types.CollectedTx

--- a/api/handler/tx/tx.go
+++ b/api/handler/tx/tx.go
@@ -133,19 +133,45 @@ func (h *TxHandler) GetTxsByAccount(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}
 
-	var query *gorm.DB
+	var (
+		query      *gorm.DB
+		msgTypeIds []int64
+	)
+
+	if len(msgs) > 0 {
+		msgTypeIds, err = h.GetMsgTypeIds(msgs)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+		}
+	}
+
+	var total int64
 	if useEdges {
-		sequenceSubQuery := tx.
+		sequenceQuery := tx.
 			Model(&types.CollectedTxAccount{}).
 			Select("sequence").
 			Where("account_id = ?", accountIds[0])
 
 		if isSigner {
-			sequenceSubQuery = sequenceSubQuery.Where("signer")
+			sequenceQuery = sequenceQuery.Where("signer")
+		}
+
+		if len(msgTypeIds) > 0 {
+			at := types.CollectedTxAccount{}.TableName()
+			mtt := types.CollectedTxMsgType{}.TableName()
+			sequenceQuery = sequenceQuery.
+				Joins("JOIN "+mtt+" ON "+mtt+".sequence = "+at+".sequence").
+				Where(mtt+".msg_type_id = ANY(?)", pq.Array(msgTypeIds))
+		}
+
+		sequenceQuery = sequenceQuery.Distinct("sequence")
+		countQuery := sequenceQuery.Session(&gorm.Session{})
+		if err := countQuery.Count(&total).Error; err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 		}
 
 		query = tx.Model(&types.CollectedTx{}).
-			Where("sequence IN (?)", sequenceSubQuery)
+			Where("sequence IN (?)", sequenceQuery)
 	} else {
 		query = tx.Model(&types.CollectedTx{}).
 			Where("account_ids && ?", pq.Array(accountIds))
@@ -153,23 +179,17 @@ func (h *TxHandler) GetTxsByAccount(c *fiber.Ctx) error {
 		if isSigner {
 			query = query.Where("signer_id = ?", accountIds[0])
 		}
-	}
 
-	if len(msgs) > 0 {
-		msgTypeIds, err := h.GetMsgTypeIds(msgs)
+		if len(msgTypeIds) > 0 {
+			query = query.Where("msg_type_ids && ?", pq.Array(msgTypeIds))
+		}
+
+		var strategy types.CollectedTx
+		hasFilters := true // always has account_ids filter
+		total, err = common.GetOptimizedCount(query, strategy, hasFilters)
 		if err != nil {
 			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 		}
-		query = query.Where("msg_type_ids && ?", pq.Array(msgTypeIds))
-	}
-
-	// Use optimized COUNT - always has filters (account_ids)
-	var strategy types.CollectedTx
-	hasFilters := true // always has account_ids filter
-	var total int64
-	total, err = common.GetOptimizedCount(query, strategy, hasFilters)
-	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}
 
 	var txs []types.CollectedTx


### PR DESCRIPTION
## Summary 

- Account-based tx, EVM tx, and internal-tx endpoints were calling GetOptimizedCount against tx/evm_tx/evm_internal_tx even after the edge backfill completed. The “sequence IN (subquery)” predicate forced PostgreSQL into a nested loop that scanned tens of thousands of edge rows and probed the main tables one-by-one, pushing COUNT(*) past 10 s.

- Each handler now switches to an edge-table driven count when backfill is ready, reusing the same sequence subquery for the main fetch and applying message/signer filters directly on the edge tables. The fallback path still uses the array-backed query for pre-backfill deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transaction endpoints now route between edge-backed and legacy query paths and use unified sequence-based pagination; responses include totals from the chosen path.

- **Bug Fixes**
  - Improved total counts and pagination consistency for edge-backed queries (deduped by sequence) and clearer error mapping when an edge/legacy path fails.

- **Tests**
  - Added edge-path tests covering message-filtered scenarios, counts, backfill behavior, and preserved legacy-path coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->