### PR TITLE
[WIP] Enhance internal transaction processing with queue management

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ const (
 	// Internal TX settings
 	DefaultInternalTxPollInterval = 5 * time.Second
 	DefaultInternalTxBatchSize    = 10
+	DefaultInternalTxQueueSize    = 100 // Default queue size
 
 	// Metrics settings
 	DefaultMetricsPath = "/metrics"
@@ -132,6 +133,7 @@ func setDefaults() {
 	viper.SetDefault("POLLING_INTERVAL", DefaultPollingInterval)
 	viper.SetDefault("INTERNAL_TX_POLL_INTERVAL", DefaultInternalTxPollInterval)
 	viper.SetDefault("INTERNAL_TX_BATCH_SIZE", DefaultInternalTxBatchSize)
+	viper.SetDefault("INTERNAL_TX_QUEUE_SIZE", DefaultInternalTxQueueSize)
 	viper.SetDefault("METRICS_ENABLED", false)
 	viper.SetDefault("METRICS_PATH", DefaultMetricsPath)
 	viper.SetDefault("METRICS_PORT", DefaultMetricsPort)
@@ -229,6 +231,7 @@ func loadConfig() (*Config, error) {
 			Enabled:      viper.GetBool("INTERNAL_TX"),
 			PollInterval: viper.GetDuration("INTERNAL_TX_POLL_INTERVAL"),
 			BatchSize:    viper.GetInt("INTERNAL_TX_BATCH_SIZE"),
+			QueueSize:    viper.GetInt("INTERNAL_TX_QUEUE_SIZE"),
 		},
 		metricsConfig: &MetricsConfig{
 			Enabled: viper.GetBool("METRICS_ENABLED"),

--- a/config/internaltx.go
+++ b/config/internaltx.go
@@ -6,6 +6,8 @@ type InternalTxConfig struct {
 	Enabled      bool
 	PollInterval time.Duration
 	BatchSize    int
+	QueueSize    int // Maximum number of heights in the queue
+
 }
 
 func (c InternalTxConfig) GetPollInterval() time.Duration {
@@ -13,4 +15,7 @@ func (c InternalTxConfig) GetPollInterval() time.Duration {
 }
 func (c InternalTxConfig) GetBatchSize() int {
 	return c.BatchSize
+}
+func (c InternalTxConfig) GetQueueSize() int {
+	return c.QueueSize
 }

--- a/indexer/extension/internaltx/collect.go
+++ b/indexer/extension/internaltx/collect.go
@@ -1,23 +1,17 @@
 package internaltx
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
-	"sync"
 
-	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5/pgconn"
-	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 
 	indexerutil "github.com/initia-labs/rollytics/indexer/util"
 	"github.com/initia-labs/rollytics/orm"
-	"github.com/initia-labs/rollytics/sentry_integration"
 	"github.com/initia-labs/rollytics/types"
 	"github.com/initia-labs/rollytics/util"
 )
@@ -25,102 +19,6 @@ import (
 type InternalTxResult struct {
 	Height    int64
 	CallTrace *DebugCallTraceBlockResponse
-}
-
-func (i *InternalTxExtension) collect(ctx context.Context, heights []int64) error {
-	// Use context-aware errgroup for cancellation support
-	g, gCtx := errgroup.WithContext(ctx)
-	scraped := make(map[int64]*InternalTxResult)
-	mu := sync.Mutex{}
-
-	// 1. Scrape internal transactions with context
-	for _, height := range heights {
-		h := height
-		g.Go(func() error {
-			// Check context before starting
-			select {
-			case <-gCtx.Done():
-				return gCtx.Err()
-			default:
-			}
-
-			span, _ := sentry_integration.StartSentrySpan(gCtx, "scrapeInternalTx", "Scraping internal transactions for height "+strconv.FormatInt(h, 10))
-			defer span.Finish()
-
-			client := fiber.AcquireClient()
-			defer fiber.ReleaseClient(client)
-
-			// TODO: Update scrapeInternalTx to support context for HTTP timeouts
-			internalTx, err := i.scrapeInternalTx(client, h)
-			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					i.logger.Info("scraping cancelled", slog.Int64("height", h))
-					return err
-				}
-				i.logger.Error("failed to scrape internal tx",
-					slog.Int64("height", h),
-					slog.Any("error", err))
-				return err
-			}
-
-			i.logger.Info("scraped internal txs", slog.Int64("height", h))
-			mu.Lock()
-			scraped[internalTx.Height] = internalTx
-			mu.Unlock()
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return err
-	}
-
-	// 2. Collect internal transactions with context check
-	for _, height := range heights {
-		// Check context before each DB operation
-		select {
-		case <-ctx.Done():
-			i.logger.Info("collection cancelled during DB save", slog.Int64("height", height))
-			return ctx.Err()
-		default:
-		}
-
-		err := func() error {
-			span, _ := sentry_integration.StartSentrySpan(ctx, "collectInternalTxs", "Collecting internal transactions for height "+strconv.FormatInt(height, 10))
-			defer span.Finish()
-
-			// TODO: Update CollectInternalTxs to use context for DB operations
-			if err := i.CollectInternalTxs(i.db, scraped[height]); err != nil {
-				if errors.Is(err, context.Canceled) {
-					return err
-				}
-				i.logger.Error("failed to collect internal txs",
-					slog.Int64("height", height),
-					slog.Any("error", err))
-				return err
-			}
-			return nil
-		}()
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Get EVM internal transactions for the debug_traceBlock
-func (i *InternalTxExtension) scrapeInternalTx(client *fiber.Client, height int64) (*InternalTxResult, error) {
-	callTraceRes, err := TraceCallByBlock(i.cfg, client, height)
-	if err != nil {
-		return nil, err
-	}
-
-	return &InternalTxResult{
-		Height:    height,
-		CallTrace: callTraceRes,
-	}, nil
 }
 
 func (i *InternalTxExtension) CollectInternalTxs(db *orm.Database, internalTx *InternalTxResult) error {

--- a/indexer/extension/internaltx/extension.go
+++ b/indexer/extension/internaltx/extension.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"sync"
 	"time"
 
+	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
 
 	"github.com/initia-labs/rollytics/config"
@@ -20,12 +23,102 @@ const ExtensionName = "internal-tx"
 
 var _ exttypes.Extension = (*InternalTxExtension)(nil)
 
+// WorkItem represents a work item containing scraped internal transaction data
+type WorkItem struct {
+	Height    int64
+	CallTrace *DebugCallTraceBlockResponse
+}
+
+// WorkQueue represents a thread-safe queue for work items
+type WorkQueue struct {
+	items    []*WorkItem
+	maxSize  int
+	mu       sync.RWMutex
+	notEmpty *sync.Cond
+	notFull  *sync.Cond
+}
+
+// NewWorkQueue creates a new work queue with the specified maximum size
+func NewWorkQueue(maxSize int) *WorkQueue {
+	wq := &WorkQueue{
+		items:   make([]*WorkItem, 0),
+		maxSize: maxSize,
+	}
+	wq.notEmpty = sync.NewCond(&wq.mu)
+	wq.notFull = sync.NewCond(&wq.mu)
+	return wq
+}
+
+// Push adds a work item to the queue, blocking if the queue is full
+func (wq *WorkQueue) Push(ctx context.Context, item *WorkItem) error {
+	wq.mu.Lock()
+	defer wq.mu.Unlock()
+
+	for len(wq.items) >= wq.maxSize {
+		wq.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			wq.mu.Lock() // Re-acquire for defer
+			return ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+			// Brief wait before retrying
+		}
+		wq.mu.Lock()
+	}
+
+	wq.items = append(wq.items, item)
+	wq.notEmpty.Signal()
+	return nil
+}
+
+// Pop removes and returns a work item from the queue, blocking if the queue is empty
+func (wq *WorkQueue) Pop(ctx context.Context) (*WorkItem, error) {
+	wq.mu.Lock()
+	defer wq.mu.Unlock()
+
+	for len(wq.items) == 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		wq.notEmpty.Wait()
+	}
+
+	item := wq.items[0]
+	wq.items = wq.items[1:]
+	wq.notFull.Signal()
+	return item, nil
+}
+
+// Size returns the current size of the queue
+func (wq *WorkQueue) Size() int {
+	wq.mu.RLock()
+	defer wq.mu.RUnlock()
+	return len(wq.items)
+}
+
+// IsNotFull returns true if the queue is not at maximum capacity
+func (wq *WorkQueue) IsNotFull() bool {
+	wq.mu.RLock()
+	defer wq.mu.RUnlock()
+	return len(wq.items) < wq.maxSize
+}
+
+// IsNotEmpty returns true if the queue has items
+func (wq *WorkQueue) IsNotEmpty() bool {
+	wq.mu.RLock()
+	defer wq.mu.RUnlock()
+	return len(wq.items) > 0
+}
+
 // InternalTxExtension is responsible for collecting and indexing internal transactions.
 type InternalTxExtension struct {
-	cfg        *config.Config
-	logger     *slog.Logger
-	db         *orm.Database
-	lastHeight int64
+	cfg                *config.Config
+	logger             *slog.Logger
+	db                 *orm.Database
+	lastProducedHeight int64 // Last produced/queued height
+	workQueue          *WorkQueue
 }
 
 func New(cfg *config.Config, logger *slog.Logger, db *orm.Database) *InternalTxExtension {
@@ -34,10 +127,43 @@ func New(cfg *config.Config, logger *slog.Logger, db *orm.Database) *InternalTxE
 	}
 
 	return &InternalTxExtension{
-		cfg:    cfg,
-		logger: logger.With("extension", ExtensionName),
-		db:     db,
+		cfg:       cfg,
+		logger:    logger.With("extension", ExtensionName),
+		db:        db,
+		workQueue: NewWorkQueue(cfg.GetInternalTxConfig().GetQueueSize()),
 	}
+}
+
+func (i *InternalTxExtension) Initialize(ctx context.Context) error {
+	// Initialize last height with context
+	var lastItx types.CollectedEvmInternalTx
+	if err := i.db.WithContext(ctx).
+		Model(types.CollectedEvmInternalTx{}).Order("height desc").First(&lastItx).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		i.logger.Error("failed to get the last block height", slog.Any("error", err))
+		return err
+	}
+
+	// Check if the next height (lastItx.Height + 1) exists and has transactions
+	nextHeight := lastItx.Height + 1
+	var exists bool
+	if err := i.db.WithContext(ctx).
+		Model(&types.CollectedBlock{}).
+		Where("chain_id = ?", i.cfg.GetChainId()).
+		Where("height = ?", nextHeight).
+		Where("tx_count > 0").
+		Select("count(*) > 0").
+		Find(&exists).Error; err != nil {
+		return fmt.Errorf("failed to check if next block exists: %w", err)
+	}
+
+	if exists {
+		i.lastProducedHeight = nextHeight
+	} else {
+		// No next block available yet, stay at current height
+		i.lastProducedHeight = lastItx.Height
+	}
+
+	return nil
 }
 
 func (i *InternalTxExtension) Run(ctx context.Context) error {
@@ -45,85 +171,162 @@ func (i *InternalTxExtension) Run(ctx context.Context) error {
 		i.logger.Warn("skipping internal transaction indexing", slog.Any("reason", err.Error()))
 		return nil
 	}
-
-	// Initialize last height with context
-	var lastItx types.CollectedEvmInternalTx
-	if err := i.db.WithContext(ctx).Model(types.CollectedEvmInternalTx{}).Order("height desc").
-		First(&lastItx).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		i.logger.Error("failed to get the last block height", slog.Any("error", err))
-		return err
-	}
-	i.lastHeight = lastItx.Height
-
-	// Use ticker instead of sleep for cancellation support
-	ticker := time.NewTicker(i.cfg.GetInternalTxConfig().GetPollInterval())
-	defer ticker.Stop()
-
-	// Initial run immediately
-	if err := i.processBatch(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		i.logger.Error("initial batch processing failed", slog.Any("error", err))
+	err := i.Initialize(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to initialize internal transaction extension: %w", err)
 	}
 
+	go i.runProducer(ctx)
+	go i.runConsumer(ctx)
+
+	// Wait for context cancellation
+	<-ctx.Done()
+	i.logger.Info("internal tx extension shutting down gracefully",
+		slog.String("reason", ctx.Err().Error()))
+	return ctx.Err()
+}
+
+// runProducer finds new block heights, scrapes data, and adds work items to the queue
+func (i *InternalTxExtension) runProducer(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			i.logger.Info("internal tx extension shutting down gracefully",
-				slog.String("reason", ctx.Err().Error()))
-			return nil
+			i.logger.Info("producer shutting down")
+			return ctx.Err()
+		default:
+			// Only produce work if queue is not full
+			if i.workQueue.IsNotFull() {
+				if err := i.produceWork(ctx); err != nil {
+					if errors.Is(err, context.Canceled) {
+						return err
+					}
+					i.logger.Error("failed to produce work",
+						slog.Any("error", err),
+						slog.Int64("last_height", i.lastProducedHeight))
 
-		case <-ticker.C:
-			if err := i.processBatch(ctx); err != nil {
-				if errors.Is(err, context.Canceled) {
-					i.logger.Info("batch processing cancelled")
-					return nil
+					// TODO: revisit wait logic
+					if i.lastProducedHeight%int64(i.cfg.GetInternalTxConfig().GetBatchSize()) == 0 {
+						time.Sleep(i.cfg.GetInternalTxConfig().GetPollInterval())
+					}
 				}
-				// Log error but continue processing
-				i.logger.Error("batch processing failed",
-					slog.Any("error", err),
-					slog.Int64("last_height", i.lastHeight))
-				// Continue to next iteration instead of panicking
+			} else {
+				// Queue is full, wait a bit before checking again
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 	}
 }
 
-// processBatch processes the next batch of blocks
-func (i *InternalTxExtension) processBatch(ctx context.Context) error {
-	transaction, ctx := sentry_integration.StartSentryTransaction(ctx, "processBatch", "Processing batch of internal transactions")
+// runConsumer processes work items from the queue
+func (i *InternalTxExtension) runConsumer(ctx context.Context) error {
+	i.logger.Info("consumer started")
+
+	for {
+		workItem, err := i.workQueue.Pop(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				i.logger.Info("consumer shutting down")
+				return err
+			}
+			i.logger.Error("failed to pop work item from queue", slog.Any("error", err))
+			continue
+		}
+
+		if err := i.consumeWork(ctx, workItem); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
+			i.logger.Error("failed to consume work item",
+				slog.Int64("height", workItem.Height),
+				slog.Any("error", err))
+			// Continue processing other work items even if one fails
+		} else {
+			i.logger.Debug("successfully processed work item", slog.Int64("height", workItem.Height))
+		}
+	}
+}
+
+// produceWork finds new block heights, scrapes internal transaction data, and queues work items
+func (i *InternalTxExtension) produceWork(ctx context.Context) error {
+	transaction, ctx := sentry_integration.StartSentryTransaction(ctx, "produceWork", "Finding and scraping new heights")
 	defer transaction.Finish()
-	var heights []int64
 
 	// Check context before DB operation
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
-	// Query blocks with context support
-	if err := i.db.WithContext(ctx).
-		Model(&types.CollectedBlock{}).
-		Where("chain_id = ?", i.cfg.GetChainId()).
-		Where("height > ?", i.lastHeight).
-		Where("tx_count > 0").
-		Order("height ASC").
-		Limit(i.cfg.GetInternalTxConfig().GetBatchSize()).
-		Pluck("height", &heights).Error; err != nil {
-		return fmt.Errorf("failed to query blocks: %w", err)
+	// Scrape internal transaction data
+	workItem, err := i.scrapeHeight(ctx, i.lastProducedHeight)
+	if err != nil {
+		return fmt.Errorf("failed to scrape height %d: %w", i.lastProducedHeight, err)
 	}
 
-	if len(heights) == 0 {
-		return nil // No new blocks to process
+	// Add work item to queue
+	if err := i.workQueue.Push(ctx, workItem); err != nil {
+		return fmt.Errorf("failed to add work item to queue: %w", err)
 	}
 
-	i.logger.Debug("processing batch",
-		slog.Int("count", len(heights)),
-		slog.Int64("from", heights[0]),
-		slog.Int64("to", heights[len(heights)-1]))
+	i.logger.Debug("produced work item",
+		slog.Int64("height", i.lastProducedHeight),
+		slog.Int("queue_size", i.workQueue.Size()))
 
-	if err := i.collect(ctx, heights); err != nil {
-		return fmt.Errorf("collect failed for heights %v: %w", heights, err)
+	// Update lastProducedHeight after successfully queuing
+	i.lastProducedHeight += 1
+	return nil
+}
+
+// scrapeHeight scrapes internal transaction data for a single height
+func (i *InternalTxExtension) scrapeHeight(ctx context.Context, height int64) (*WorkItem, error) {
+	span, _ := sentry_integration.StartSentrySpan(ctx, "scrapeHeight", "Scraping internal transactions for height "+strconv.FormatInt(height, 10))
+	defer span.Finish()
+
+	client := fiber.AcquireClient()
+	defer fiber.ReleaseClient(client)
+
+	// Scrape internal transaction data
+	callTraceRes, err := TraceCallByBlock(i.cfg, client, height)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			i.logger.Info("scraping cancelled", slog.Int64("height", height))
+			return nil, err
+		}
+		i.logger.Error("failed to scrape internal tx",
+			slog.Int64("height", height),
+			slog.Any("error", err))
+		return nil, err
 	}
 
-	i.lastHeight = heights[len(heights)-1]
+	i.logger.Info("scraped internal txs", slog.Int64("height", height))
+
+	return &WorkItem{
+		Height:    height,
+		CallTrace: callTraceRes,
+	}, nil
+}
+
+// consumeWork processes a work item by saving it to the database
+func (i *InternalTxExtension) consumeWork(ctx context.Context, workItem *WorkItem) error {
+	span, _ := sentry_integration.StartSentrySpan(ctx, "consumeWork", "Processing internal transactions for height "+strconv.FormatInt(workItem.Height, 10))
+	defer span.Finish()
+
+	// Convert WorkItem to InternalTxResult for compatibility with existing method
+	internalTxResult := &InternalTxResult{
+		Height:    workItem.Height,
+		CallTrace: workItem.CallTrace,
+	}
+
+	// Use existing CollectInternalTxs method to save to database
+	if err := i.CollectInternalTxs(i.db, internalTxResult); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		i.logger.Error("failed to collect internal txs",
+			slog.Int64("height", workItem.Height),
+			slog.Any("error", err))
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- Added a new `QueueSize` configuration option for internal transactions.
- Implemented a thread-safe `WorkQueue` to manage work items for scraping internal transactions.
- Refactored the `InternalTxExtension` to utilize the work queue for producing and consuming work items.
- Updated methods to handle the new queue structure, improving efficiency and scalability in processing internal transactions.