### PR TITLE
refactor: enhance channel buffering and concurrency control in indexe…

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -52,9 +52,11 @@ func New(cfg *config.Config, logger *slog.Logger, db *orm.Database) *Indexer {
 		collector:        collector.New(cfg, logger, db),
 		extensionManager: extension.New(cfg, logger, db),
 		blockMap:         make(map[int64]indexertypes.ScrapedBlock),
-		blockChan:        make(chan indexertypes.ScrapedBlock),
-		controlChan:      make(chan string),
-		querier:          querier.NewQuerier(cfg.GetChainConfig()),
+		// Buffering reduces backpressure stalls between scraper -> prepare when downstream is briefly slow.
+		// It also prevents fastSync goroutines from piling up solely because the channel is unbuffered.
+		blockChan:   make(chan indexertypes.ScrapedBlock, types.MaxInflightBlocks),
+		controlChan: make(chan string, 1),
+		querier:     querier.NewQuerier(cfg.GetChainConfig()),
 	}
 }
 

--- a/indexer/scraper/sync.go
+++ b/indexer/scraper/sync.go
@@ -30,6 +30,14 @@ func (s *Scraper) fastSync(ctx context.Context, client *fiber.Client, height int
 		wg           sync.WaitGroup
 	)
 
+	// Limit the number of concurrent scraping goroutines.
+	// This prevents unbounded goroutine growth when downstream (prepare/collect/DB) is slow.
+	maxConc := s.cfg.GetMaxConcurrentRequests()
+	if maxConc < 1 {
+		maxConc = 1
+	}
+	sem := make(chan struct{}, maxConc)
+
 	go func() {
 		for signal := range controlChan {
 			switch signal {
@@ -74,9 +82,11 @@ func (s *Scraper) fastSync(ctx context.Context, client *fiber.Client, height int
 
 		// spin up new goroutine for scraping block with incrementing height
 		h := height
+		sem <- struct{}{}
 		wg.Add(1)
 		go func(errCount int) {
 			defer wg.Done()
+			defer func() { <-sem }()
 
 			for {
 				select {

--- a/indexer/scraper/sync.go
+++ b/indexer/scraper/sync.go
@@ -108,7 +108,11 @@ func (s *Scraper) fastSync(ctx context.Context, client *fiber.Client, height int
 				// if no error, cache the scraped block to block map and return
 				if err == nil {
 					s.logger.Info("scraped block", slog.Int64("height", block.Height))
-					blockChan <- block
+					select {
+					case blockChan <- block:
+					case <-ctx.Done():
+						return
+					}
 					s.trackScrapedBlock()
 
 					s.mtx.Lock()
@@ -164,7 +168,11 @@ func (s *Scraper) slowSync(ctx context.Context, client *fiber.Client, height int
 
 				if err == nil {
 					s.logger.Info("scraped block", slog.Int64("height", block.Height))
-					blockChan <- block
+					select {
+					case blockChan <- block:
+					case <-ctx.Done():
+						return nil
+					}
 					s.trackScrapedBlock()
 				} else if !reachedLatestHeight(fmt.Sprintf("%+v", err)) {
 					// log only if it is not related to reached latest height error

--- a/indexer/scraper/sync.go
+++ b/indexer/scraper/sync.go
@@ -82,7 +82,15 @@ func (s *Scraper) fastSync(ctx context.Context, client *fiber.Client, height int
 
 		// spin up new goroutine for scraping block with incrementing height
 		h := height
-		sem <- struct{}{}
+		select {
+		case sem <- struct{}{}:
+			// acquired a slot; safe to spawn and account in wg
+		case <-ctx.Done():
+			s.logger.Info("fastSync() shutting down gracefully")
+			wg.Wait()
+			return syncedHeight
+		}
+
 		wg.Add(1)
 		go func(errCount int) {
 			defer wg.Done()


### PR DESCRIPTION
…r and scraper

- Updated blockChan and controlChan in the indexer to use buffered channels, reducing backpressure and improving performance during scraping.
- Introduced a semaphore in the scraper's fastSync method to limit concurrent scraping goroutines, preventing unbounded growth and ensuring stability when downstream processing is slow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Capped concurrent indexing workers and added buffering between pipeline stages to reduce backpressure and prevent worker pile‑up.
  * Improved shutdown handling so in‑flight tasks respect cancellation, release resources, and avoid blocking during termination.
  * Stability and efficiency improvements under heavy load; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->